### PR TITLE
feat: add OpenTelemetry metrics export via Anthropic SDK instrumentor

### DIFF
--- a/docs/plans/2026-04-03-otel-metrics-design.md
+++ b/docs/plans/2026-04-03-otel-metrics-design.md
@@ -11,7 +11,7 @@ Add OpenTelemetry metrics export to the remote-agent service, focused on Claude 
 
 - **Metrics only** (no tracing or log export through OTel for now)
 - **OTLP export to external collector** (no in-process HTTP metrics endpoint)
-- **Community instrumentor** (`opentelemetry-instrumentation-claude-agent-sdk`) for automatic `query()` instrumentation
+- **Community instrumentor** (`opentelemetry-instrumentation-anthropic`) for automatic `query()` instrumentation
 - **Config docs only** for collector setup (no docker-compose included)
 - **Opt-in** via config toggle (disabled by default)
 
@@ -21,7 +21,7 @@ Add OpenTelemetry metrics export to the remote-agent service, focused on Claude 
 opentelemetry-api
 opentelemetry-sdk
 opentelemetry-exporter-otlp-proto-grpc
-opentelemetry-instrumentation-claude-agent-sdk
+opentelemetry-instrumentation-anthropic
 ```
 
 ## Architecture
@@ -31,7 +31,7 @@ main.py startup
   └── setup_telemetry(config)
         ├── if disabled: no-op return
         ├── configure TracerProvider with OTLP exporter
-        └── ClaudeAgentSdkInstrumentor().instrument()
+        └── AnthropicInstrumentor().instrument()
 
 agent.py query() calls  ──(auto-patched)──>  OTel spans  ──>  OTLP gRPC  ──>  Collector  ──>  Prometheus
 ```
@@ -41,7 +41,7 @@ agent.py query() calls  ──(auto-patched)──>  OTel spans  ──>  OTLP g
 Responsibilities:
 1. Read telemetry config (endpoint, service name, enabled flag)
 2. Configure `TracerProvider` with `OTLPSpanExporter`
-3. Call `ClaudeAgentSdkInstrumentor().instrument()`
+3. Call `AnthropicInstrumentor().instrument()`
 4. No-op when telemetry is disabled
 
 ### Config Addition

--- a/docs/plans/2026-04-03-otel-metrics-design.md
+++ b/docs/plans/2026-04-03-otel-metrics-design.md
@@ -1,0 +1,83 @@
+# OTel Metrics Export via Claude Agent SDK Instrumentor
+
+**Date:** 2026-04-03
+**Status:** Approved
+
+## Goal
+
+Add OpenTelemetry metrics export to the remote-agent service, focused on Claude Agent SDK call telemetry (token usage, model, tool calls, durations). Metrics are exported via OTLP to an external OTel Collector that Prometheus can scrape.
+
+## Decisions
+
+- **Metrics only** (no tracing or log export through OTel for now)
+- **OTLP export to external collector** (no in-process HTTP metrics endpoint)
+- **Community instrumentor** (`opentelemetry-instrumentation-claude-agent-sdk`) for automatic `query()` instrumentation
+- **Config docs only** for collector setup (no docker-compose included)
+- **Opt-in** via config toggle (disabled by default)
+
+## Dependencies
+
+```
+opentelemetry-api
+opentelemetry-sdk
+opentelemetry-exporter-otlp-proto-grpc
+opentelemetry-instrumentation-claude-agent-sdk
+```
+
+## Architecture
+
+```
+main.py startup
+  └── setup_telemetry(config)
+        ├── if disabled: no-op return
+        ├── configure TracerProvider with OTLP exporter
+        └── ClaudeAgentSdkInstrumentor().instrument()
+
+agent.py query() calls  ──(auto-patched)──>  OTel spans  ──>  OTLP gRPC  ──>  Collector  ──>  Prometheus
+```
+
+### New Module: `src/remote_agent/telemetry.py`
+
+Responsibilities:
+1. Read telemetry config (endpoint, service name, enabled flag)
+2. Configure `TracerProvider` with `OTLPSpanExporter`
+3. Call `ClaudeAgentSdkInstrumentor().instrument()`
+4. No-op when telemetry is disabled
+
+### Config Addition
+
+```yaml
+telemetry:
+  enabled: false                         # opt-in
+  otlp_endpoint: "http://localhost:4317" # gRPC OTLP endpoint
+  service_name: "remote-agent"
+```
+
+New `TelemetryConfig` dataclass in `config.py`.
+
+### Changes to Existing Files
+
+| File | Change |
+|------|--------|
+| `main.py` | Call `setup_telemetry(config)` after config loads, before poll loop |
+| `config.py` | Add `TelemetryConfig` dataclass and `telemetry` field |
+| `pyproject.toml` | Add OTel dependencies |
+| `agent.py` | No changes (instrumentor patches `query()` automatically) |
+
+### What Gets Emitted
+
+The community instrumentor captures per `query()` call:
+- `invoke_agent` spans: model name, input/output token counts, finish reason, duration
+- `execute_tool` child spans: tool name, duration, success/failure
+- Follows GenAI semantic conventions
+
+## Testing
+
+- Unit test `telemetry.py`: verify instrumentor is called when enabled, no-op when disabled
+- Existing tests unaffected since `agent.py` is not modified
+
+## Future Work
+
+- Add custom operational metrics (poll latency, queue depth, phase durations, budget tracking)
+- Add distributed tracing with span propagation across phases
+- Export structured logs through OTel

--- a/docs/plans/2026-04-03-otel-metrics-plan.md
+++ b/docs/plans/2026-04-03-otel-metrics-plan.md
@@ -1,0 +1,414 @@
+# OTel Metrics Export Implementation Plan
+
+> **For Claude:** REQUIRED SUB-SKILL: Use superpowers:executing-plans to implement this plan task-by-task.
+
+**Goal:** Wire up `opentelemetry-instrumentation-claude-agent-sdk` so every `query()` call automatically emits OTel spans exported via OTLP to an external collector.
+
+**Architecture:** A new `telemetry.py` module configures a `TracerProvider` with an OTLP exporter and calls `ClaudeAgentSdkInstrumentor().instrument()` at startup. Config is opt-in via a `telemetry` section in `config.yaml`. No changes to `agent.py` — the instrumentor patches `query()` automatically.
+
+**Tech Stack:** `opentelemetry-api`, `opentelemetry-sdk`, `opentelemetry-exporter-otlp-proto-grpc`, `opentelemetry-instrumentation-claude-agent-sdk`
+
+---
+
+### Task 1: Add TelemetryConfig to config.py
+
+**Files:**
+- Modify: `src/remote_agent/config.py:55-69` (add dataclass before `Config`, add field to `Config`)
+- Modify: `src/remote_agent/config.py:108-118` (wire into `load_config`)
+- Test: `tests/test_config.py`
+
+**Step 1: Write the failing test**
+
+Add to `tests/test_config.py`:
+
+```python
+def test_load_config_telemetry_defaults(tmp_path):
+    config_file = tmp_path / "config.yaml"
+    config_file.write_text("""
+repos:
+  - owner: "o"
+    name: "r"
+users:
+  - "u"
+polling:
+  interval_seconds: 60
+trigger:
+  label: "agent"
+workspace:
+  base_dir: "/tmp/ws"
+database:
+  path: "data/test.db"
+agent:
+  default_model: "sonnet"
+  planning_model: "opus"
+  implementation_model: "sonnet"
+  review_model: "sonnet"
+  orchestrator_model: "haiku"
+  max_turns: 200
+  max_budget_usd: 10.0
+  daily_budget_usd: 50.0
+""")
+    config = load_config(str(config_file))
+    assert config.telemetry.enabled is False
+    assert config.telemetry.otlp_endpoint == "http://localhost:4317"
+    assert config.telemetry.service_name == "remote-agent"
+
+
+def test_load_config_telemetry_custom(tmp_path):
+    config_file = tmp_path / "config.yaml"
+    config_file.write_text("""
+repos:
+  - owner: "o"
+    name: "r"
+users:
+  - "u"
+polling:
+  interval_seconds: 60
+trigger:
+  label: "agent"
+workspace:
+  base_dir: "/tmp/ws"
+database:
+  path: "data/test.db"
+agent:
+  default_model: "sonnet"
+  planning_model: "opus"
+  implementation_model: "sonnet"
+  review_model: "sonnet"
+  orchestrator_model: "haiku"
+  max_turns: 200
+  max_budget_usd: 10.0
+  daily_budget_usd: 50.0
+telemetry:
+  enabled: true
+  otlp_endpoint: "http://collector:4317"
+  service_name: "my-agent"
+""")
+    config = load_config(str(config_file))
+    assert config.telemetry.enabled is True
+    assert config.telemetry.otlp_endpoint == "http://collector:4317"
+    assert config.telemetry.service_name == "my-agent"
+```
+
+**Step 2: Run test to verify it fails**
+
+Run: `pytest tests/test_config.py::test_load_config_telemetry_defaults tests/test_config.py::test_load_config_telemetry_custom -v`
+Expected: FAIL with `AttributeError: 'Config' object has no attribute 'telemetry'`
+
+**Step 3: Write minimal implementation**
+
+In `src/remote_agent/config.py`, add the `TelemetryConfig` dataclass after `AutoUpdateConfig`:
+
+```python
+@dataclass
+class TelemetryConfig:
+    enabled: bool = False
+    otlp_endpoint: str = "http://localhost:4317"
+    service_name: str = "remote-agent"
+```
+
+Add to the `Config` dataclass:
+
+```python
+    telemetry: TelemetryConfig = field(default_factory=TelemetryConfig)
+```
+
+In `load_config`, add before the `return Config(...)` statement:
+
+```python
+    telemetry=TelemetryConfig(**raw.get("telemetry", {})),
+```
+
+**Step 4: Run test to verify it passes**
+
+Run: `pytest tests/test_config.py -v`
+Expected: All tests PASS
+
+**Step 5: Commit**
+
+```bash
+git add src/remote_agent/config.py tests/test_config.py
+git commit -m "feat: add TelemetryConfig for OTel metrics export"
+```
+
+---
+
+### Task 2: Add OTel dependencies to pyproject.toml
+
+**Files:**
+- Modify: `pyproject.toml:9-13` (add telemetry optional dependency group)
+
+**Step 1: Add telemetry dependency group**
+
+Add a new optional dependency group in `pyproject.toml` under `[project.optional-dependencies]`:
+
+```toml
+telemetry = [
+    "opentelemetry-api>=1.20.0",
+    "opentelemetry-sdk>=1.20.0",
+    "opentelemetry-exporter-otlp-proto-grpc>=1.20.0",
+    "opentelemetry-instrumentation-claude-agent-sdk>=0.1.0",
+]
+```
+
+This keeps OTel deps optional — users install with `pip install -e ".[telemetry]"`.
+
+**Step 2: Verify install**
+
+Run: `pip install -e ".[telemetry]"`
+Expected: All OTel packages install successfully
+
+**Step 3: Commit**
+
+```bash
+git add pyproject.toml
+git commit -m "feat: add opentelemetry optional dependency group"
+```
+
+---
+
+### Task 3: Create telemetry.py module
+
+**Files:**
+- Create: `src/remote_agent/telemetry.py`
+- Test: `tests/test_telemetry.py`
+
+**Step 1: Write the failing tests**
+
+Create `tests/test_telemetry.py`:
+
+```python
+from unittest.mock import patch, MagicMock
+from remote_agent.config import TelemetryConfig
+from remote_agent.telemetry import setup_telemetry
+
+
+def test_setup_telemetry_disabled_is_noop():
+    config = TelemetryConfig(enabled=False)
+    with patch("remote_agent.telemetry.TracerProvider", create=True) as mock_tp:
+        setup_telemetry(config)
+        mock_tp.assert_not_called()
+
+
+def test_setup_telemetry_enabled_configures_provider():
+    config = TelemetryConfig(
+        enabled=True,
+        otlp_endpoint="http://localhost:4317",
+        service_name="test-agent",
+    )
+    mock_instrumentor = MagicMock()
+    with (
+        patch("remote_agent.telemetry.TracerProvider") as mock_tp_cls,
+        patch("remote_agent.telemetry.OTLPSpanExporter") as mock_exporter_cls,
+        patch("remote_agent.telemetry.BatchSpanProcessor") as mock_bsp_cls,
+        patch("remote_agent.telemetry.trace") as mock_trace,
+        patch("remote_agent.telemetry.ClaudeAgentSdkInstrumentor", return_value=mock_instrumentor) as mock_instr_cls,
+        patch("remote_agent.telemetry.Resource") as mock_resource_cls,
+    ):
+        setup_telemetry(config)
+
+        # Verify provider was created and set
+        mock_tp_cls.assert_called_once()
+        mock_trace.set_tracer_provider.assert_called_once()
+
+        # Verify exporter uses configured endpoint
+        mock_exporter_cls.assert_called_once_with(endpoint="http://localhost:4317")
+
+        # Verify instrumentor was called
+        mock_instrumentor.instrument.assert_called_once()
+
+
+def test_setup_telemetry_missing_deps_logs_warning():
+    config = TelemetryConfig(enabled=True)
+    with (
+        patch("remote_agent.telemetry.HAS_OTEL", False),
+        patch("remote_agent.telemetry.logger") as mock_logger,
+    ):
+        setup_telemetry(config)
+        mock_logger.warning.assert_called_once()
+```
+
+**Step 2: Run tests to verify they fail**
+
+Run: `pytest tests/test_telemetry.py -v`
+Expected: FAIL with `ModuleNotFoundError` or `ImportError`
+
+**Step 3: Write the implementation**
+
+Create `src/remote_agent/telemetry.py`:
+
+```python
+# src/remote_agent/telemetry.py
+from __future__ import annotations
+import logging
+
+from remote_agent.config import TelemetryConfig
+
+logger = logging.getLogger(__name__)
+
+try:
+    from opentelemetry import trace
+    from opentelemetry.sdk.trace import TracerProvider
+    from opentelemetry.sdk.trace.export import BatchSpanProcessor
+    from opentelemetry.exporter.otlp.proto.grpc.trace_exporter import OTLPSpanExporter
+    from opentelemetry.sdk.resources import Resource
+    from opentelemetry.instrumentation.claude_agent_sdk import ClaudeAgentSdkInstrumentor
+    HAS_OTEL = True
+except ImportError:
+    HAS_OTEL = False
+
+
+def setup_telemetry(config: TelemetryConfig) -> None:
+    if not config.enabled:
+        return
+
+    if not HAS_OTEL:
+        logger.warning(
+            "Telemetry enabled but opentelemetry packages not installed. "
+            "Install with: pip install -e '.[telemetry]'"
+        )
+        return
+
+    resource = Resource.create({"service.name": config.service_name})
+    provider = TracerProvider(resource=resource)
+    exporter = OTLPSpanExporter(endpoint=config.otlp_endpoint)
+    provider.add_span_processor(BatchSpanProcessor(exporter))
+    trace.set_tracer_provider(provider)
+
+    ClaudeAgentSdkInstrumentor().instrument()
+
+    logger.info(
+        "Telemetry enabled: exporting to %s as %s",
+        config.otlp_endpoint, config.service_name,
+    )
+```
+
+**Step 4: Run tests to verify they pass**
+
+Run: `pytest tests/test_telemetry.py -v`
+Expected: All 3 tests PASS
+
+**Step 5: Commit**
+
+```bash
+git add src/remote_agent/telemetry.py tests/test_telemetry.py
+git commit -m "feat: add telemetry module with OTel SDK instrumentor setup"
+```
+
+---
+
+### Task 4: Wire setup_telemetry into main.py
+
+**Files:**
+- Modify: `src/remote_agent/main.py:51-56` (add telemetry setup call after config loads)
+- Test: `tests/test_main.py`
+
+**Step 1: Write the failing test**
+
+Add to `tests/test_main.py`. The existing tests use real config files via `tmp_path` and patch constructors at the module level. Follow the same pattern:
+
+```python
+async def test_run_calls_setup_telemetry(tmp_path):
+    config_file = tmp_path / "config.yaml"
+    config_file.write_text("""
+repos:
+  - owner: "o"
+    name: "r"
+users:
+  - "u"
+polling:
+  interval_seconds: 1
+trigger:
+  label: "agent"
+workspace:
+  base_dir: "/tmp/ws"
+database:
+  path: "data/test.db"
+agent:
+  default_model: "sonnet"
+  planning_model: "opus"
+  implementation_model: "sonnet"
+  review_model: "sonnet"
+  orchestrator_model: "haiku"
+  max_turns: 200
+  max_budget_usd: 10.0
+  daily_budget_usd: 50.0
+telemetry:
+  enabled: true
+  otlp_endpoint: "http://collector:4317"
+  service_name: "test-agent"
+""")
+    with patch("remote_agent.main.Poller") as mock_poller_cls, \
+         patch("remote_agent.main.Dispatcher") as mock_disp_cls, \
+         patch("remote_agent.main.setup_telemetry") as mock_setup_tel:
+        mock_poller_cls.return_value = AsyncMock()
+        mock_disp = AsyncMock()
+        mock_disp.process_events.side_effect = KeyboardInterrupt
+        mock_disp_cls.return_value = mock_disp
+        try:
+            await run(str(config_file))
+        except KeyboardInterrupt:
+            pass
+
+        mock_setup_tel.assert_called_once()
+        call_arg = mock_setup_tel.call_args[0][0]
+        assert call_arg.enabled is True
+        assert call_arg.otlp_endpoint == "http://collector:4317"
+```
+
+**Step 2: Run test to verify it fails**
+
+Run: `pytest tests/test_main.py::test_run_calls_setup_telemetry -v`
+Expected: FAIL — `setup_telemetry` not imported or called
+
+**Step 3: Write minimal implementation**
+
+In `src/remote_agent/main.py`, add the import and call. After line 55 (`setup_logging(app.config)`), add:
+
+```python
+    from remote_agent.telemetry import setup_telemetry
+    setup_telemetry(app.config.telemetry)
+```
+
+**Step 4: Run test to verify it passes**
+
+Run: `pytest tests/test_main.py -v`
+Expected: All tests PASS
+
+**Step 5: Run full test suite**
+
+Run: `pytest -v`
+Expected: All tests PASS
+
+**Step 6: Commit**
+
+```bash
+git add src/remote_agent/main.py tests/test_main.py
+git commit -m "feat: wire telemetry setup into main startup"
+```
+
+---
+
+### Task 5: Final verification and cleanup
+
+**Step 1: Run full test suite**
+
+Run: `pytest -v`
+Expected: All tests PASS
+
+**Step 2: Verify telemetry install works**
+
+Run: `pip install -e ".[telemetry]" && python -c "from remote_agent.telemetry import setup_telemetry; print('OK')"`
+Expected: Prints `OK`
+
+**Step 3: Verify service starts with telemetry disabled (default)**
+
+Run: `python -c "from remote_agent.config import TelemetryConfig; from remote_agent.telemetry import setup_telemetry; setup_telemetry(TelemetryConfig()); print('noop OK')"`
+Expected: Prints `noop OK` (no errors, no OTel setup)
+
+**Step 4: Commit plan doc**
+
+```bash
+git add docs/plans/2026-04-03-otel-metrics-plan.md
+git commit -m "docs: add OTel metrics implementation plan"
+```

--- a/docs/plans/2026-04-03-otel-metrics-plan.md
+++ b/docs/plans/2026-04-03-otel-metrics-plan.md
@@ -2,11 +2,11 @@
 
 > **For Claude:** REQUIRED SUB-SKILL: Use superpowers:executing-plans to implement this plan task-by-task.
 
-**Goal:** Wire up `opentelemetry-instrumentation-claude-agent-sdk` so every `query()` call automatically emits OTel spans exported via OTLP to an external collector.
+**Goal:** Wire up `opentelemetry-instrumentation-anthropic` so every `query()` call automatically emits OTel spans exported via OTLP to an external collector.
 
-**Architecture:** A new `telemetry.py` module configures a `TracerProvider` with an OTLP exporter and calls `ClaudeAgentSdkInstrumentor().instrument()` at startup. Config is opt-in via a `telemetry` section in `config.yaml`. No changes to `agent.py` — the instrumentor patches `query()` automatically.
+**Architecture:** A new `telemetry.py` module configures a `TracerProvider` with an OTLP exporter and calls `AnthropicInstrumentor().instrument()` at startup. Config is opt-in via a `telemetry` section in `config.yaml`. No changes to `agent.py` — the instrumentor patches `query()` automatically.
 
-**Tech Stack:** `opentelemetry-api`, `opentelemetry-sdk`, `opentelemetry-exporter-otlp-proto-grpc`, `opentelemetry-instrumentation-claude-agent-sdk`
+**Tech Stack:** `opentelemetry-api`, `opentelemetry-sdk`, `opentelemetry-exporter-otlp-proto-grpc`, `opentelemetry-instrumentation-anthropic`
 
 ---
 
@@ -147,7 +147,7 @@ telemetry = [
     "opentelemetry-api>=1.20.0",
     "opentelemetry-sdk>=1.20.0",
     "opentelemetry-exporter-otlp-proto-grpc>=1.20.0",
-    "opentelemetry-instrumentation-claude-agent-sdk>=0.1.0",
+    "opentelemetry-instrumentation-anthropic>=0.1.0",
 ]
 ```
 
@@ -202,7 +202,7 @@ def test_setup_telemetry_enabled_configures_provider():
         patch("remote_agent.telemetry.OTLPSpanExporter") as mock_exporter_cls,
         patch("remote_agent.telemetry.BatchSpanProcessor") as mock_bsp_cls,
         patch("remote_agent.telemetry.trace") as mock_trace,
-        patch("remote_agent.telemetry.ClaudeAgentSdkInstrumentor", return_value=mock_instrumentor) as mock_instr_cls,
+        patch("remote_agent.telemetry.AnthropicInstrumentor", return_value=mock_instrumentor) as mock_instr_cls,
         patch("remote_agent.telemetry.Resource") as mock_resource_cls,
     ):
         setup_telemetry(config)
@@ -252,7 +252,7 @@ try:
     from opentelemetry.sdk.trace.export import BatchSpanProcessor
     from opentelemetry.exporter.otlp.proto.grpc.trace_exporter import OTLPSpanExporter
     from opentelemetry.sdk.resources import Resource
-    from opentelemetry.instrumentation.claude_agent_sdk import ClaudeAgentSdkInstrumentor
+    from opentelemetry.instrumentation.claude_agent_sdk import AnthropicInstrumentor
     HAS_OTEL = True
 except ImportError:
     HAS_OTEL = False
@@ -275,7 +275,7 @@ def setup_telemetry(config: TelemetryConfig) -> None:
     provider.add_span_processor(BatchSpanProcessor(exporter))
     trace.set_tracer_provider(provider)
 
-    ClaudeAgentSdkInstrumentor().instrument()
+    AnthropicInstrumentor().instrument()
 
     logger.info(
         "Telemetry enabled: exporting to %s as %s",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -17,6 +17,12 @@ dev = [
     "pytest>=8.0",
     "pytest-asyncio>=0.23",
 ]
+telemetry = [
+    "opentelemetry-api>=1.20.0",
+    "opentelemetry-sdk>=1.20.0",
+    "opentelemetry-exporter-otlp-proto-grpc>=1.20.0",
+    "opentelemetry-instrumentation-anthropic>=0.50.0",
+]
 
 [tool.pytest.ini_options]
 asyncio_mode = "auto"

--- a/src/remote_agent/config.py
+++ b/src/remote_agent/config.py
@@ -57,6 +57,13 @@ class AutoUpdateConfig:
 
 
 @dataclass
+class TelemetryConfig:
+    enabled: bool = False
+    otlp_endpoint: str = "http://localhost:4317"
+    service_name: str = "remote-agent"
+
+
+@dataclass
 class Config:
     repos: list[RepoConfig]
     users: list[str]
@@ -67,6 +74,7 @@ class Config:
     agent: AgentConfig
     logging: LoggingConfig = field(default_factory=LoggingConfig)
     auto_update: AutoUpdateConfig = field(default_factory=AutoUpdateConfig)
+    telemetry: TelemetryConfig = field(default_factory=TelemetryConfig)
 
 
 def load_config(config_path: str) -> Config:
@@ -115,4 +123,5 @@ def load_config(config_path: str) -> Config:
         agent=AgentConfig(**raw.get("agent", {})),
         logging=LoggingConfig(**logging_raw),
         auto_update=AutoUpdateConfig(**raw.get("auto_update", {})),
+        telemetry=TelemetryConfig(**raw.get("telemetry", {})),
     )

--- a/src/remote_agent/main.py
+++ b/src/remote_agent/main.py
@@ -54,6 +54,9 @@ async def run(config_path: str = "config.yaml"):
     from remote_agent.logging_config import setup_logging
     setup_logging(app.config)
 
+    from remote_agent.telemetry import setup_telemetry
+    setup_telemetry(app.config.telemetry)
+
     logger.info("Remote agent started. Polling %d repos every %ds.",
                 len(app.config.repos), app.config.polling.interval_seconds)
 

--- a/src/remote_agent/main.py
+++ b/src/remote_agent/main.py
@@ -14,6 +14,7 @@ from remote_agent.poller import Poller
 from remote_agent.dispatcher import Dispatcher
 from remote_agent.audit import AuditLogger
 from remote_agent.updater import AutoUpdater
+from remote_agent.telemetry import setup_telemetry
 
 logger = logging.getLogger("remote_agent")
 
@@ -54,7 +55,6 @@ async def run(config_path: str = "config.yaml"):
     from remote_agent.logging_config import setup_logging
     setup_logging(app.config)
 
-    from remote_agent.telemetry import setup_telemetry
     setup_telemetry(app.config.telemetry)
 
     logger.info("Remote agent started. Polling %d repos every %ds.",

--- a/src/remote_agent/telemetry.py
+++ b/src/remote_agent/telemetry.py
@@ -1,0 +1,46 @@
+# src/remote_agent/telemetry.py
+from __future__ import annotations
+
+import logging
+
+from remote_agent.config import TelemetryConfig
+
+logger = logging.getLogger(__name__)
+
+try:
+    from opentelemetry import trace
+    from opentelemetry.sdk.trace import TracerProvider
+    from opentelemetry.sdk.trace.export import BatchSpanProcessor
+    from opentelemetry.exporter.otlp.proto.grpc.trace_exporter import OTLPSpanExporter
+    from opentelemetry.sdk.resources import Resource
+    from opentelemetry.instrumentation.anthropic import AnthropicInstrumentor
+
+    HAS_OTEL = True
+except ImportError:
+    HAS_OTEL = False
+
+
+def setup_telemetry(config: TelemetryConfig) -> None:
+    if not config.enabled:
+        return
+
+    if not HAS_OTEL:
+        logger.warning(
+            "Telemetry enabled but opentelemetry packages not installed. "
+            "Install with: pip install -e '.[telemetry]'"
+        )
+        return
+
+    resource = Resource.create({"service.name": config.service_name})
+    provider = TracerProvider(resource=resource)
+    exporter = OTLPSpanExporter(endpoint=config.otlp_endpoint)
+    provider.add_span_processor(BatchSpanProcessor(exporter))
+    trace.set_tracer_provider(provider)
+
+    AnthropicInstrumentor().instrument()
+
+    logger.info(
+        "Telemetry enabled: exporting to %s as %s",
+        config.otlp_endpoint,
+        config.service_name,
+    )

--- a/src/remote_agent/telemetry.py
+++ b/src/remote_agent/telemetry.py
@@ -20,8 +20,16 @@ except ImportError:
     HAS_OTEL = False
 
 
+_initialized = False
+
+
 def setup_telemetry(config: TelemetryConfig) -> None:
+    global _initialized
+
     if not config.enabled:
+        return
+
+    if _initialized:
         return
 
     if not HAS_OTEL:
@@ -38,6 +46,7 @@ def setup_telemetry(config: TelemetryConfig) -> None:
     trace.set_tracer_provider(provider)
 
     AnthropicInstrumentor().instrument()
+    _initialized = True
 
     logger.info(
         "Telemetry enabled: exporting to %s as %s",

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -141,6 +141,74 @@ agent:
     assert config.auto_update.enabled is False
 
 
+def test_load_config_telemetry_defaults(tmp_path):
+    config_file = tmp_path / "config.yaml"
+    config_file.write_text("""
+repos:
+  - owner: "o"
+    name: "r"
+users:
+  - "u"
+polling:
+  interval_seconds: 60
+trigger:
+  label: "agent"
+workspace:
+  base_dir: "/tmp/ws"
+database:
+  path: "data/test.db"
+agent:
+  default_model: "sonnet"
+  planning_model: "opus"
+  implementation_model: "sonnet"
+  review_model: "sonnet"
+  orchestrator_model: "haiku"
+  max_turns: 200
+  max_budget_usd: 10.0
+  daily_budget_usd: 50.0
+""")
+    config = load_config(str(config_file))
+    assert config.telemetry.enabled is False
+    assert config.telemetry.otlp_endpoint == "http://localhost:4317"
+    assert config.telemetry.service_name == "remote-agent"
+
+
+def test_load_config_telemetry_custom(tmp_path):
+    config_file = tmp_path / "config.yaml"
+    config_file.write_text("""
+repos:
+  - owner: "o"
+    name: "r"
+users:
+  - "u"
+polling:
+  interval_seconds: 60
+trigger:
+  label: "agent"
+workspace:
+  base_dir: "/tmp/ws"
+database:
+  path: "data/test.db"
+agent:
+  default_model: "sonnet"
+  planning_model: "opus"
+  implementation_model: "sonnet"
+  review_model: "sonnet"
+  orchestrator_model: "haiku"
+  max_turns: 200
+  max_budget_usd: 10.0
+  daily_budget_usd: 50.0
+telemetry:
+  enabled: true
+  otlp_endpoint: "http://collector:4317"
+  service_name: "my-agent"
+""")
+    config = load_config(str(config_file))
+    assert config.telemetry.enabled is True
+    assert config.telemetry.otlp_endpoint == "http://collector:4317"
+    assert config.telemetry.service_name == "my-agent"
+
+
 def test_agent_config_default_orchestrator_model_is_sonnet():
     from remote_agent.config import AgentConfig
     config = AgentConfig()

--- a/tests/test_main.py
+++ b/tests/test_main.py
@@ -286,7 +286,7 @@ telemetry:
 """)
     with patch("remote_agent.main.Poller") as mock_poller_cls, \
          patch("remote_agent.main.Dispatcher") as mock_disp_cls, \
-         patch("remote_agent.telemetry.setup_telemetry") as mock_setup_tel:
+         patch("remote_agent.main.setup_telemetry") as mock_setup_tel:
         mock_poller_cls.return_value = AsyncMock()
         mock_disp = AsyncMock()
         mock_disp.process_events.side_effect = KeyboardInterrupt

--- a/tests/test_main.py
+++ b/tests/test_main.py
@@ -252,3 +252,51 @@ auto_update:
 
     assert call_count == 2  # Loop continued past pull failure
     mock_updater.pull_update.assert_called_once()
+
+
+async def test_run_calls_setup_telemetry(tmp_path):
+    config_file = tmp_path / "config.yaml"
+    config_file.write_text("""
+repos:
+  - owner: "o"
+    name: "r"
+users:
+  - "u"
+polling:
+  interval_seconds: 1
+trigger:
+  label: "agent"
+workspace:
+  base_dir: "/tmp/ws"
+database:
+  path: "data/test.db"
+agent:
+  default_model: "sonnet"
+  planning_model: "opus"
+  implementation_model: "sonnet"
+  review_model: "sonnet"
+  orchestrator_model: "haiku"
+  max_turns: 200
+  max_budget_usd: 10.0
+  daily_budget_usd: 50.0
+telemetry:
+  enabled: true
+  otlp_endpoint: "http://collector:4317"
+  service_name: "test-agent"
+""")
+    with patch("remote_agent.main.Poller") as mock_poller_cls, \
+         patch("remote_agent.main.Dispatcher") as mock_disp_cls, \
+         patch("remote_agent.telemetry.setup_telemetry") as mock_setup_tel:
+        mock_poller_cls.return_value = AsyncMock()
+        mock_disp = AsyncMock()
+        mock_disp.process_events.side_effect = KeyboardInterrupt
+        mock_disp_cls.return_value = mock_disp
+        try:
+            await run(str(config_file))
+        except KeyboardInterrupt:
+            pass
+
+        mock_setup_tel.assert_called_once()
+        call_arg = mock_setup_tel.call_args[0][0]
+        assert call_arg.enabled is True
+        assert call_arg.otlp_endpoint == "http://collector:4317"

--- a/tests/test_telemetry.py
+++ b/tests/test_telemetry.py
@@ -1,0 +1,48 @@
+from unittest.mock import patch, MagicMock
+from remote_agent.config import TelemetryConfig
+from remote_agent.telemetry import setup_telemetry
+
+
+def test_setup_telemetry_disabled_is_noop():
+    config = TelemetryConfig(enabled=False)
+    with patch("remote_agent.telemetry.TracerProvider", create=True) as mock_tp:
+        setup_telemetry(config)
+        mock_tp.assert_not_called()
+
+
+def test_setup_telemetry_enabled_configures_provider():
+    config = TelemetryConfig(
+        enabled=True,
+        otlp_endpoint="http://localhost:4317",
+        service_name="test-agent",
+    )
+    mock_instrumentor = MagicMock()
+    with (
+        patch("remote_agent.telemetry.TracerProvider") as mock_tp_cls,
+        patch("remote_agent.telemetry.OTLPSpanExporter") as mock_exporter_cls,
+        patch("remote_agent.telemetry.BatchSpanProcessor") as mock_bsp_cls,
+        patch("remote_agent.telemetry.trace") as mock_trace,
+        patch("remote_agent.telemetry.AnthropicInstrumentor", return_value=mock_instrumentor) as mock_instr_cls,
+        patch("remote_agent.telemetry.Resource") as mock_resource_cls,
+    ):
+        setup_telemetry(config)
+
+        # Verify provider was created and set
+        mock_tp_cls.assert_called_once()
+        mock_trace.set_tracer_provider.assert_called_once()
+
+        # Verify exporter uses configured endpoint
+        mock_exporter_cls.assert_called_once_with(endpoint="http://localhost:4317")
+
+        # Verify instrumentor was called
+        mock_instrumentor.instrument.assert_called_once()
+
+
+def test_setup_telemetry_missing_deps_logs_warning():
+    config = TelemetryConfig(enabled=True)
+    with (
+        patch("remote_agent.telemetry.HAS_OTEL", False),
+        patch("remote_agent.telemetry.logger") as mock_logger,
+    ):
+        setup_telemetry(config)
+        mock_logger.warning.assert_called_once()

--- a/tests/test_telemetry.py
+++ b/tests/test_telemetry.py
@@ -1,12 +1,22 @@
 from __future__ import annotations
 from unittest.mock import patch, MagicMock
+import pytest
 from remote_agent.config import TelemetryConfig
 from remote_agent.telemetry import setup_telemetry
+import remote_agent.telemetry as telemetry_module
+
+
+@pytest.fixture(autouse=True)
+def reset_telemetry_state():
+    telemetry_module._initialized = False
+    yield
+    telemetry_module._initialized = False
 
 
 def test_setup_telemetry_disabled_is_noop():
     config = TelemetryConfig(enabled=False)
-    with patch("remote_agent.telemetry.TracerProvider", create=True) as mock_tp:
+    with patch("remote_agent.telemetry.HAS_OTEL", True), \
+         patch("remote_agent.telemetry.TracerProvider") as mock_tp:
         setup_telemetry(config)
         mock_tp.assert_not_called()
 

--- a/tests/test_telemetry.py
+++ b/tests/test_telemetry.py
@@ -1,3 +1,4 @@
+from __future__ import annotations
 from unittest.mock import patch, MagicMock
 from remote_agent.config import TelemetryConfig
 from remote_agent.telemetry import setup_telemetry


### PR DESCRIPTION
## Summary

- Add opt-in OpenTelemetry instrumentation that patches the Anthropic SDK (used by `claude-agent-sdk`) to emit spans via OTLP to an external collector compatible with Prometheus
- New `telemetry` optional dependency group (`pip install -e ".[telemetry]"`) with `opentelemetry-instrumentation-anthropic` and OTel SDK packages
- New `TelemetryConfig` in config and `setup_telemetry()` module called at startup — disabled by default, no-op when deps aren't installed

### Usage
```yaml
telemetry:
  enabled: true
  otlp_endpoint: "http://your-collector:4317"
  service_name: "remote-agent"
```

## Test plan
- [x] 3 telemetry tests: disabled noop, enabled configures provider, missing deps warning
- [x] 2 config tests: defaults when section absent, custom values
- [x] 1 main wiring test: verifies setup_telemetry called with correct config
- [x] Full suite: 250 tests passing