### PR TITLE
feat: replace OTLP push telemetry with Prometheus /metrics endpoint

### DIFF
--- a/docs/plans/2026-04-03-otel-metrics-design.md
+++ b/docs/plans/2026-04-03-otel-metrics-design.md
@@ -1,7 +1,9 @@
+> **SUPERSEDED** by [2026-04-04-prometheus-metrics-design.md](2026-04-04-prometheus-metrics-design.md)
+
 # OTel Metrics Export via Claude Agent SDK Instrumentor
 
 **Date:** 2026-04-03
-**Status:** Approved
+**Status:** Superseded
 
 ## Goal
 

--- a/docs/plans/2026-04-04-prometheus-metrics-design.md
+++ b/docs/plans/2026-04-04-prometheus-metrics-design.md
@@ -1,0 +1,159 @@
+# Prometheus Metrics via In-Process /metrics Endpoint
+
+**Date:** 2026-04-04
+**Status:** Approved
+**Supersedes:** 2026-04-03-otel-metrics-design.md (OTLP push model)
+
+## Goal
+
+Replace the OTLP gRPC push telemetry (PR #13) with an in-process `/metrics` HTTP endpoint that Prometheus can scrape directly. The service runs on an isolated VM with no OTel Collector, making push-based export unworkable.
+
+## Decisions
+
+- **Drop entire OTel stack** — TracerProvider, OTLP exporter, BatchSpanProcessor, AnthropicInstrumentor all removed
+- **prometheus_client + aiohttp** for metric definitions and HTTP serving
+- **Explicit instrumentation** in `agent.py._run_query()` using `ResultMessage.model_usage` for per-model token/cost breakdown
+- **Metric names follow `remote_agent_*` convention**, aligned with Claude Code's `claude_code_*` metric schema (same counter types, same token type labels, same model labels)
+- **Telemetry module owns the HTTP server lifecycle** — `setup_telemetry()` starts it, `shutdown_telemetry()` stops it
+- **No high-cardinality labels** — no `session_id`, `issue_number`, or user identity labels in Prometheus
+
+## Metrics
+
+| Metric | Type | Labels | Source |
+|--------|------|--------|--------|
+| `remote_agent_session_count_total` | Counter | `repo`, `phase`, `model` | Each `_run_query` completion (model = orchestrator model) |
+| `remote_agent_token_usage_total` | Counter | `repo`, `phase`, `model`, `type` | `model_usage` from `ResultMessage`; `type` ∈ {`input`, `output`, `cacheRead`, `cacheCreation`} |
+| `remote_agent_cost_usage_total` | Counter | `repo`, `phase`, `model` | `model_usage[model]["costUSD"]` per model (unit: USD) |
+| `remote_agent_active_time_total` | Counter | `repo`, `phase`, `type` | `ResultMessage.duration_ms` / 1000 (`type=agent`), `duration_api_ms` / 1000 (`type=api`) |
+| `remote_agent_query_errors_total` | Counter | `repo`, `phase`, `model` | `_run_query` exception path |
+| `remote_agent_pull_request_count_total` | Counter | `repo` | `github.create_pr` calls |
+| `remote_agent_phase_transitions_total` | Counter | `repo`, `from_phase`, `to_phase` | Dispatcher phase changes |
+
+### Label values
+
+- **`repo`**: `"owner/name"` from config
+- **`phase`**: `designing`, `planning`, `implementing`, `design_review`, `code_review`, `{context}_question`
+- **`model`**: model name string from `model_usage` keys (e.g. `claude-sonnet-4-6`, `claude-opus-4-6[1m]`)
+- **`type`** (token_usage): `input`, `output`, `cacheRead`, `cacheCreation` — matches Claude Code's label values
+- **`type`** (active_time): `agent`, `api` — derived from `duration_ms` and `duration_api_ms`
+
+### Data source: `ResultMessage.model_usage`
+
+The SDK's `model_usage` dict is keyed by model name with camelCase inner keys:
+
+```python
+{
+    "claude-sonnet-4-6": {
+        "inputTokens": 1500,
+        "outputTokens": 800,
+        "cacheReadInputTokens": 100,
+        "cacheCreationInputTokens": 200,
+        "costUSD": 0.015,
+    }
+}
+```
+
+This gives per-model breakdown including cache token types, matching Claude Code's format.
+
+## Architecture
+
+```
+telemetry.py
+├── Module-level prometheus_client metric objects
+├── record_query_metrics(repo, phase, model_usage, duration_ms, duration_api_ms)
+├── record_query_error(repo, phase, model)
+├── record_pr_created(repo)
+├── record_phase_transition(repo, from_phase, to_phase)
+├── setup_telemetry(config) → starts aiohttp server on config.metrics_port
+└── shutdown_telemetry() → stops the aiohttp server
+
+agent.py._run_query()
+├── Extract model_usage from ResultMessage (new field access)
+├── Extract duration_ms, duration_api_ms from ResultMessage (new)
+└── Call telemetry.record_query_metrics() on success
+└── Call telemetry.record_query_error() on exception
+
+github.py.create_pr()
+└── Call telemetry.record_pr_created()
+
+dispatcher.py (phase transitions)
+└── Call telemetry.record_phase_transition()
+
+main.py
+├── setup_telemetry(config.telemetry) at startup (existing call site)
+└── shutdown_telemetry() in finally block (new)
+```
+
+## Config Changes
+
+### Before (PR #13)
+
+```python
+@dataclass
+class TelemetryConfig:
+    enabled: bool = False
+    otlp_endpoint: str = "http://localhost:4317"
+    service_name: str = "remote-agent"
+```
+
+### After
+
+```python
+@dataclass
+class TelemetryConfig:
+    enabled: bool = False
+    metrics_port: int = 9090
+    service_name: str = "remote-agent"
+```
+
+```yaml
+telemetry:
+  enabled: false
+  metrics_port: 9090
+  service_name: "remote-agent"
+```
+
+## Dependency Changes
+
+### Remove (pyproject.toml `[telemetry]` extra)
+
+```
+opentelemetry-api
+opentelemetry-sdk
+opentelemetry-exporter-otlp-proto-grpc
+opentelemetry-instrumentation-anthropic
+```
+
+### Add
+
+```
+prometheus_client>=0.20.0
+aiohttp>=3.9.0
+```
+
+## File Changes Summary
+
+| File | Change |
+|------|--------|
+| `telemetry.py` | Complete rewrite: OTel → prometheus_client + aiohttp server |
+| `config.py` | `TelemetryConfig`: `otlp_endpoint` → `metrics_port: int = 9090` |
+| `agent.py` | `_run_query`: extract `model_usage`, `duration_ms`, `duration_api_ms`; call `record_query_metrics`/`record_query_error` |
+| `github.py` | `create_pr`: call `record_pr_created` |
+| `dispatcher.py` | Phase transitions: call `record_phase_transition` |
+| `main.py` | Add `shutdown_telemetry()` in finally block |
+| `pyproject.toml` | Swap OTel deps for prometheus_client + aiohttp |
+| `tests/test_telemetry.py` | Rewrite to test new metrics + HTTP server |
+
+## Testing
+
+- **telemetry.py**: verify metrics are registered, `record_*` functions increment counters, aiohttp server starts/stops
+- **agent.py**: verify `record_query_metrics` called with correct model_usage data after query
+- **Existing tests**: mock `telemetry.record_*` calls (they're no-ops when telemetry disabled anyway)
+- Integration: hit `/metrics` endpoint, verify Prometheus text format output
+
+## Not In Scope
+
+- `lines_of_code_count_total` — edits happen inside SDK sessions, we don't see diffs
+- `commit_count_total` — commits happen inside agent sessions opaquely
+- `code_edit_tool_decision_total` — no interactive permission decisions (headless agent)
+- `num_turns` tracking — available on ResultMessage but not in Claude Code's metric set

--- a/docs/plans/2026-04-04-prometheus-metrics-plan.md
+++ b/docs/plans/2026-04-04-prometheus-metrics-plan.md
@@ -1,0 +1,1009 @@
+# Prometheus Metrics Endpoint — Implementation Plan
+
+> **For Claude:** REQUIRED SUB-SKILL: Use superpowers:executing-plans to implement this plan task-by-task.
+
+**Goal:** Replace OTLP gRPC push telemetry with an in-process `/metrics` HTTP endpoint using prometheus_client + aiohttp.
+
+**Architecture:** `telemetry.py` owns metric definitions and an aiohttp server lifecycle. `agent.py`, `github.py`, and `dispatcher.py` call thin `record_*` functions that are no-ops when telemetry is disabled. Config swaps `otlp_endpoint` for `metrics_port`.
+
+**Tech Stack:** `prometheus_client>=0.20.0`, `aiohttp>=3.9.0`, Python 3.11+
+
+**Design doc:** `docs/plans/2026-04-04-prometheus-metrics-design.md`
+
+---
+
+### Task 1: Update dependencies in pyproject.toml
+
+**Files:**
+- Modify: `pyproject.toml:20-25` (the `[telemetry]` optional-dependencies)
+
+**Step 1: Replace the telemetry dependencies**
+
+Change the `telemetry` extra from:
+
+```toml
+telemetry = [
+    "opentelemetry-api>=1.20.0",
+    "opentelemetry-sdk>=1.20.0",
+    "opentelemetry-exporter-otlp-proto-grpc>=1.20.0",
+    "opentelemetry-instrumentation-anthropic>=0.50.0",
+]
+```
+
+To:
+
+```toml
+telemetry = [
+    "prometheus_client>=0.20.0",
+    "aiohttp>=3.9.0",
+]
+```
+
+**Step 2: Install the new deps**
+
+Run: `pip install -e ".[dev,telemetry]"`
+Expected: Success, `prometheus_client` and `aiohttp` installed.
+
+**Step 3: Commit**
+
+```bash
+git add pyproject.toml
+git commit -m "chore: swap OTel deps for prometheus_client + aiohttp"
+```
+
+---
+
+### Task 2: Update TelemetryConfig in config.py
+
+**Files:**
+- Modify: `src/remote_agent/config.py:60-63` (TelemetryConfig dataclass)
+- Test: `tests/test_config.py`
+
+**Step 1: Write the failing test**
+
+Add to `tests/test_config.py`:
+
+```python
+def test_telemetry_config_metrics_port():
+    """TelemetryConfig should have metrics_port, not otlp_endpoint."""
+    from remote_agent.config import TelemetryConfig
+
+    config = TelemetryConfig()
+    assert config.metrics_port == 9090
+    assert config.service_name == "remote-agent"
+    assert config.enabled is False
+    assert not hasattr(config, "otlp_endpoint")
+```
+
+**Step 2: Run test to verify it fails**
+
+Run: `pytest tests/test_config.py::test_telemetry_config_metrics_port -v`
+Expected: FAIL — `AttributeError: 'TelemetryConfig' object has no attribute 'metrics_port'`
+
+**Step 3: Update TelemetryConfig**
+
+In `src/remote_agent/config.py`, replace lines 60-63:
+
+```python
+@dataclass
+class TelemetryConfig:
+    enabled: bool = False
+    metrics_port: int = 9090
+    service_name: str = "remote-agent"
+```
+
+**Step 4: Run test to verify it passes**
+
+Run: `pytest tests/test_config.py::test_telemetry_config_metrics_port -v`
+Expected: PASS
+
+**Step 5: Run full config test suite for regressions**
+
+Run: `pytest tests/test_config.py -v`
+Expected: All pass. If any test references `otlp_endpoint`, update it to `metrics_port`.
+
+**Step 6: Commit**
+
+```bash
+git add src/remote_agent/config.py tests/test_config.py
+git commit -m "feat: replace otlp_endpoint with metrics_port in TelemetryConfig"
+```
+
+---
+
+### Task 3: Rewrite telemetry.py — metric definitions and record functions
+
+**Files:**
+- Rewrite: `src/remote_agent/telemetry.py`
+- Test: `tests/test_telemetry.py`
+
+**Step 1: Write failing tests for the record functions**
+
+Replace `tests/test_telemetry.py` entirely with:
+
+```python
+from __future__ import annotations
+from unittest.mock import patch, AsyncMock, MagicMock
+import pytest
+from remote_agent.config import TelemetryConfig
+import remote_agent.telemetry as telemetry_module
+
+
+@pytest.fixture(autouse=True)
+def reset_telemetry_state():
+    telemetry_module._initialized = False
+    telemetry_module._server_runner = None
+    telemetry_module._server_site = None
+    yield
+    telemetry_module._initialized = False
+    telemetry_module._server_runner = None
+    telemetry_module._server_site = None
+
+
+def test_record_query_metrics_disabled_is_noop():
+    """record_query_metrics should silently do nothing when telemetry is not initialized."""
+    # Should not raise even when prometheus_client is not configured
+    telemetry_module.record_query_metrics(
+        repo="owner/repo", phase="designing",
+        model_usage={"claude-sonnet-4-6": {"inputTokens": 100, "outputTokens": 50, "costUSD": 0.01}},
+        duration_ms=1000, duration_api_ms=800,
+    )
+
+
+def test_record_query_metrics_increments_counters():
+    """record_query_metrics should increment all metric counters when enabled."""
+    with patch("remote_agent.telemetry.HAS_PROMETHEUS", True):
+        telemetry_module._initialized = True
+
+        model_usage = {
+            "claude-sonnet-4-6": {
+                "inputTokens": 1500,
+                "outputTokens": 800,
+                "cacheReadInputTokens": 100,
+                "cacheCreationInputTokens": 200,
+                "costUSD": 0.015,
+            },
+        }
+
+        telemetry_module.record_query_metrics(
+            repo="owner/repo", phase="designing",
+            model_usage=model_usage,
+            duration_ms=5000, duration_api_ms=4000,
+        )
+
+        # Verify session counter incremented
+        val = telemetry_module.SESSION_COUNT.labels(
+            repo="owner/repo", phase="designing", model="claude-sonnet-4-6",
+        )._value.get()
+        assert val == 1.0
+
+        # Verify token counters
+        val = telemetry_module.TOKEN_USAGE.labels(
+            repo="owner/repo", phase="designing", model="claude-sonnet-4-6", type="input",
+        )._value.get()
+        assert val == 1500.0
+
+        val = telemetry_module.TOKEN_USAGE.labels(
+            repo="owner/repo", phase="designing", model="claude-sonnet-4-6", type="cacheRead",
+        )._value.get()
+        assert val == 100.0
+
+        # Verify cost counter
+        val = telemetry_module.COST_USAGE.labels(
+            repo="owner/repo", phase="designing", model="claude-sonnet-4-6",
+        )._value.get()
+        assert val == 0.015
+
+        # Verify active time counters
+        val = telemetry_module.ACTIVE_TIME.labels(
+            repo="owner/repo", phase="designing", type="agent",
+        )._value.get()
+        assert val == 5.0  # 5000ms -> 5s
+
+        val = telemetry_module.ACTIVE_TIME.labels(
+            repo="owner/repo", phase="designing", type="api",
+        )._value.get()
+        assert val == 4.0  # 4000ms -> 4s
+
+
+def test_record_query_metrics_multiple_models():
+    """record_query_metrics should handle multi-model usage (subagents)."""
+    with patch("remote_agent.telemetry.HAS_PROMETHEUS", True):
+        telemetry_module._initialized = True
+
+        model_usage = {
+            "claude-sonnet-4-6": {
+                "inputTokens": 1000, "outputTokens": 500,
+                "cacheReadInputTokens": 0, "cacheCreationInputTokens": 0,
+                "costUSD": 0.01,
+            },
+            "claude-opus-4-6[1m]": {
+                "inputTokens": 2000, "outputTokens": 1000,
+                "cacheReadInputTokens": 500, "cacheCreationInputTokens": 100,
+                "costUSD": 0.05,
+            },
+        }
+
+        telemetry_module.record_query_metrics(
+            repo="owner/repo", phase="implementing",
+            model_usage=model_usage,
+            duration_ms=10000, duration_api_ms=8000,
+        )
+
+        # Both models should have session counts
+        val_sonnet = telemetry_module.SESSION_COUNT.labels(
+            repo="owner/repo", phase="implementing", model="claude-sonnet-4-6",
+        )._value.get()
+        val_opus = telemetry_module.SESSION_COUNT.labels(
+            repo="owner/repo", phase="implementing", model="claude-opus-4-6[1m]",
+        )._value.get()
+        assert val_sonnet == 1.0
+        assert val_opus == 1.0
+
+
+def test_record_query_error_increments_counter():
+    """record_query_error should increment the error counter."""
+    with patch("remote_agent.telemetry.HAS_PROMETHEUS", True):
+        telemetry_module._initialized = True
+
+        telemetry_module.record_query_error(
+            repo="owner/repo", phase="designing", model="claude-sonnet-4-6",
+        )
+
+        val = telemetry_module.QUERY_ERRORS.labels(
+            repo="owner/repo", phase="designing", model="claude-sonnet-4-6",
+        )._value.get()
+        assert val == 1.0
+
+
+def test_record_pr_created_increments_counter():
+    """record_pr_created should increment the PR counter."""
+    with patch("remote_agent.telemetry.HAS_PROMETHEUS", True):
+        telemetry_module._initialized = True
+
+        telemetry_module.record_pr_created(repo="owner/repo")
+
+        val = telemetry_module.PR_COUNT.labels(repo="owner/repo")._value.get()
+        assert val == 1.0
+
+
+def test_record_phase_transition_increments_counter():
+    """record_phase_transition should increment the transition counter."""
+    with patch("remote_agent.telemetry.HAS_PROMETHEUS", True):
+        telemetry_module._initialized = True
+
+        telemetry_module.record_phase_transition(
+            repo="owner/repo", from_phase="designing", to_phase="design_review",
+        )
+
+        val = telemetry_module.PHASE_TRANSITIONS.labels(
+            repo="owner/repo", from_phase="designing", to_phase="design_review",
+        )._value.get()
+        assert val == 1.0
+
+
+def test_setup_telemetry_disabled_is_noop():
+    """setup_telemetry should be a no-op when disabled."""
+    config = TelemetryConfig(enabled=False)
+    # Should not start any server
+    telemetry_module.setup_telemetry(config)
+    assert not telemetry_module._initialized
+
+
+def test_setup_telemetry_missing_deps_logs_warning():
+    """setup_telemetry should warn when prometheus_client is not installed."""
+    config = TelemetryConfig(enabled=True)
+    with (
+        patch("remote_agent.telemetry.HAS_PROMETHEUS", False),
+        patch("remote_agent.telemetry.logger") as mock_logger,
+    ):
+        telemetry_module.setup_telemetry(config)
+        mock_logger.warning.assert_called_once()
+        assert not telemetry_module._initialized
+```
+
+**Step 2: Run tests to verify they fail**
+
+Run: `pytest tests/test_telemetry.py -v`
+Expected: FAIL — old telemetry.py doesn't have the new functions or metric objects.
+
+**Step 3: Rewrite telemetry.py**
+
+Replace `src/remote_agent/telemetry.py` entirely with:
+
+```python
+# src/remote_agent/telemetry.py
+from __future__ import annotations
+
+import logging
+
+from remote_agent.config import TelemetryConfig
+
+logger = logging.getLogger(__name__)
+
+try:
+    from prometheus_client import Counter, CollectorRegistry, generate_latest
+    from aiohttp import web
+
+    HAS_PROMETHEUS = True
+except ImportError:
+    HAS_PROMETHEUS = False
+
+
+_initialized = False
+_server_runner: object | None = None
+_server_site: object | None = None
+
+# -- Metric definitions (safe to define even if prometheus_client missing) --
+
+if HAS_PROMETHEUS:
+    REGISTRY = CollectorRegistry()
+
+    SESSION_COUNT = Counter(
+        "remote_agent_session_count_total",
+        "Count of agent query sessions",
+        ["repo", "phase", "model"],
+        registry=REGISTRY,
+    )
+
+    TOKEN_USAGE = Counter(
+        "remote_agent_token_usage_total",
+        "Number of tokens used",
+        ["repo", "phase", "model", "type"],
+        registry=REGISTRY,
+    )
+
+    COST_USAGE = Counter(
+        "remote_agent_cost_usage_total",
+        "Cost of agent queries in USD",
+        ["repo", "phase", "model"],
+        registry=REGISTRY,
+    )
+
+    ACTIVE_TIME = Counter(
+        "remote_agent_active_time_total",
+        "Total active time in seconds",
+        ["repo", "phase", "type"],
+        registry=REGISTRY,
+    )
+
+    QUERY_ERRORS = Counter(
+        "remote_agent_query_errors_total",
+        "Count of failed agent queries",
+        ["repo", "phase", "model"],
+        registry=REGISTRY,
+    )
+
+    PR_COUNT = Counter(
+        "remote_agent_pull_request_count_total",
+        "Number of pull requests created",
+        ["repo"],
+        registry=REGISTRY,
+    )
+
+    PHASE_TRANSITIONS = Counter(
+        "remote_agent_phase_transitions_total",
+        "Count of issue phase transitions",
+        ["repo", "from_phase", "to_phase"],
+        registry=REGISTRY,
+    )
+
+
+# -- Record functions (no-op when not initialized) --
+
+
+def record_query_metrics(
+    *, repo: str, phase: str, model_usage: dict | None,
+    duration_ms: int, duration_api_ms: int,
+) -> None:
+    if not _initialized or not model_usage:
+        return
+
+    for model, usage in model_usage.items():
+        SESSION_COUNT.labels(repo=repo, phase=phase, model=model).inc()
+        COST_USAGE.labels(repo=repo, phase=phase, model=model).inc(
+            usage.get("costUSD", 0),
+        )
+        for token_type, key in [
+            ("input", "inputTokens"),
+            ("output", "outputTokens"),
+            ("cacheRead", "cacheReadInputTokens"),
+            ("cacheCreation", "cacheCreationInputTokens"),
+        ]:
+            TOKEN_USAGE.labels(
+                repo=repo, phase=phase, model=model, type=token_type,
+            ).inc(usage.get(key, 0))
+
+    ACTIVE_TIME.labels(repo=repo, phase=phase, type="agent").inc(duration_ms / 1000)
+    ACTIVE_TIME.labels(repo=repo, phase=phase, type="api").inc(duration_api_ms / 1000)
+
+
+def record_query_error(*, repo: str, phase: str, model: str) -> None:
+    if not _initialized:
+        return
+    QUERY_ERRORS.labels(repo=repo, phase=phase, model=model).inc()
+
+
+def record_pr_created(*, repo: str) -> None:
+    if not _initialized:
+        return
+    PR_COUNT.labels(repo=repo).inc()
+
+
+def record_phase_transition(*, repo: str, from_phase: str, to_phase: str) -> None:
+    if not _initialized:
+        return
+    PHASE_TRANSITIONS.labels(repo=repo, from_phase=from_phase, to_phase=to_phase).inc()
+
+
+# -- Server lifecycle --
+
+
+async def _metrics_handler(request: web.Request) -> web.Response:
+    body = generate_latest(REGISTRY)
+    return web.Response(body=body, content_type="text/plain; version=0.0.4; charset=utf-8")
+
+
+def setup_telemetry(config: TelemetryConfig) -> None:
+    global _initialized
+
+    if not config.enabled:
+        return
+
+    if _initialized:
+        return
+
+    if not HAS_PROMETHEUS:
+        logger.warning(
+            "Telemetry enabled but prometheus_client/aiohttp not installed. "
+            "Install with: pip install -e '.[telemetry]'"
+        )
+        return
+
+    _initialized = True
+    logger.info(
+        "Telemetry enabled: /metrics on port %d as %s",
+        config.metrics_port, config.service_name,
+    )
+
+
+async def start_metrics_server(config: TelemetryConfig) -> None:
+    global _server_runner, _server_site
+
+    if not _initialized:
+        return
+
+    app = web.Application()
+    app.router.add_get("/metrics", _metrics_handler)
+
+    runner = web.AppRunner(app)
+    await runner.setup()
+    site = web.TCPSite(runner, "0.0.0.0", config.metrics_port)
+    await site.start()
+
+    _server_runner = runner
+    _server_site = site
+
+    logger.info("Metrics server listening on port %d", config.metrics_port)
+
+
+async def shutdown_telemetry() -> None:
+    global _server_runner, _server_site, _initialized
+
+    if _server_runner:
+        await _server_runner.cleanup()
+        _server_runner = None
+        _server_site = None
+        logger.info("Metrics server stopped")
+```
+
+**Step 4: Run tests to verify they pass**
+
+Run: `pytest tests/test_telemetry.py -v`
+Expected: All pass.
+
+**Step 5: Commit**
+
+```bash
+git add src/remote_agent/telemetry.py tests/test_telemetry.py
+git commit -m "feat: rewrite telemetry with prometheus_client metrics and aiohttp server"
+```
+
+---
+
+### Task 4: Wire telemetry into main.py (server lifecycle)
+
+**Files:**
+- Modify: `src/remote_agent/main.py:58` and `main.py:83-86` (finally block)
+- Test: `tests/test_main.py`
+
+**Step 1: Check existing main.py tests**
+
+Run: `pytest tests/test_main.py -v`
+Expected: All pass (baseline).
+
+**Step 2: Update main.py**
+
+In `src/remote_agent/main.py`, add the import for the new async functions. Change the import on line 17 from:
+
+```python
+from remote_agent.telemetry import setup_telemetry
+```
+
+To:
+
+```python
+from remote_agent.telemetry import setup_telemetry, start_metrics_server, shutdown_telemetry
+```
+
+After line 58 (`setup_telemetry(app.config.telemetry)`), add:
+
+```python
+    await start_metrics_server(app.config.telemetry)
+```
+
+In the `finally` block (after line 85 `await app.db.close()`), add:
+
+```python
+        await shutdown_telemetry()
+```
+
+The `run()` function should look like:
+
+```python
+async def run(config_path: str = "config.yaml"):
+    # Phase 1: minimal console logging until config is available
+    logging.basicConfig(level=logging.INFO)
+
+    app = await create_app(config_path)
+
+    # Phase 2: reconfigure with structured JSON logging
+    from remote_agent.logging_config import setup_logging
+    setup_logging(app.config)
+
+    setup_telemetry(app.config.telemetry)
+    await start_metrics_server(app.config.telemetry)
+
+    logger.info("Remote agent started. Polling %d repos every %ds.",
+                len(app.config.repos), app.config.polling.interval_seconds)
+
+    await app.dispatcher.recover_interrupted_issues()
+
+    try:
+        while True:
+            try:
+                await app.poller.poll_once()
+                await app.dispatcher.process_events()
+            except Exception:
+                logger.exception("Unexpected error in main loop")
+            if app.updater:
+                try:
+                    if await app.updater.check_for_update():
+                        await app.updater.pull_update()
+                        logger.info("Update applied, restarting...")
+                        sys.exit(42)
+                except SystemExit:
+                    raise
+                except Exception:
+                    logger.exception("Update check failed, continuing...")
+            await asyncio.sleep(app.config.polling.interval_seconds)
+    finally:
+        if app.audit:
+            app.audit.close()
+        await app.db.close()
+        await shutdown_telemetry()
+```
+
+**Step 3: Run main.py tests**
+
+Run: `pytest tests/test_main.py -v`
+Expected: All pass. If any test mocks `setup_telemetry`, it may need to also mock `start_metrics_server` and `shutdown_telemetry`. Check for `ImportError` or `AttributeError` in failures and patch accordingly.
+
+**Step 4: Commit**
+
+```bash
+git add src/remote_agent/main.py tests/test_main.py
+git commit -m "feat: wire metrics server start/shutdown into main.py lifecycle"
+```
+
+---
+
+### Task 5: Instrument agent.py._run_query with telemetry calls
+
+**Files:**
+- Modify: `src/remote_agent/agent.py:158-211` (`_run_query` method)
+- Test: `tests/test_agent.py` (if it exists, add test; otherwise create)
+
+**Step 1: Write the failing test**
+
+Add a test (in existing agent test file or new `tests/test_agent_telemetry.py`):
+
+```python
+from __future__ import annotations
+from unittest.mock import patch, AsyncMock, MagicMock
+from dataclasses import dataclass
+from remote_agent.agent import AgentService, AgentResult
+
+
+@dataclass
+class FakeResultMessage:
+    subtype: str = "result"
+    duration_ms: int = 5000
+    duration_api_ms: int = 4000
+    is_error: bool = False
+    num_turns: int = 3
+    session_id: str = "test-session"
+    total_cost_usd: float = 0.05
+    usage: dict = None
+    result: str = "done"
+    model_usage: dict = None
+
+    def __post_init__(self):
+        if self.usage is None:
+            self.usage = {"input_tokens": 1500, "output_tokens": 800}
+        if self.model_usage is None:
+            self.model_usage = {
+                "claude-sonnet-4-6": {
+                    "inputTokens": 1500,
+                    "outputTokens": 800,
+                    "cacheReadInputTokens": 0,
+                    "cacheCreationInputTokens": 0,
+                    "costUSD": 0.05,
+                }
+            }
+
+
+async def test_run_query_calls_record_query_metrics():
+    """_run_query should call record_query_metrics with model_usage from ResultMessage."""
+    mock_db = MagicMock()
+    mock_db.create_agent_run = AsyncMock(return_value=1)
+    mock_db.get_latest_session_for_phase = AsyncMock(return_value=None)
+    mock_db.complete_agent_run = AsyncMock()
+
+    mock_config = MagicMock()
+    service = AgentService(mock_config, mock_db)
+
+    msg = FakeResultMessage()
+
+    async def fake_query(**kwargs):
+        yield msg
+
+    mock_options = MagicMock()
+    mock_options.model = "sonnet"
+
+    with (
+        patch("remote_agent.agent.query", side_effect=fake_query),
+        patch("remote_agent.agent.ResultMessage", FakeResultMessage),
+        patch("remote_agent.telemetry.record_query_metrics") as mock_record,
+    ):
+        result = await service._run_query("test prompt", mock_options, issue_id=1, phase="designing")
+
+        mock_record.assert_called_once_with(
+            repo="",
+            phase="designing",
+            model_usage=msg.model_usage,
+            duration_ms=5000,
+            duration_api_ms=4000,
+        )
+```
+
+**Step 2: Run to verify it fails**
+
+Run: `pytest tests/test_agent_telemetry.py::test_run_query_calls_record_query_metrics -v`
+Expected: FAIL — `record_query_metrics` is not yet called in `_run_query`.
+
+**Step 3: Add telemetry calls to _run_query**
+
+In `src/remote_agent/agent.py`, add at the top (after existing imports):
+
+```python
+from remote_agent.telemetry import record_query_metrics, record_query_error
+```
+
+In the `_run_query` method, add these variables after `output_tokens = 0` (line 177):
+
+```python
+        model_usage = None
+        duration_ms = 0
+        duration_api_ms = 0
+```
+
+Inside the `if isinstance(message, ResultMessage):` block (after line 190), add:
+
+```python
+                    model_usage = message.model_usage
+                    duration_ms = message.duration_ms
+                    duration_api_ms = message.duration_api_ms
+```
+
+After the `logger.info("Completed %s query...")` line (line 192), add:
+
+```python
+            record_query_metrics(
+                repo=getattr(getattr(self.config, '_current_repo', None), '', ''),
+                phase=phase,
+                model_usage=model_usage,
+                duration_ms=duration_ms,
+                duration_api_ms=duration_api_ms,
+            )
+```
+
+**WAIT** — `_run_query` doesn't have access to `repo`. The callers (`run_designing`, etc.) don't pass repo info to `_run_query`. We need to thread `repo` through.
+
+Update `_run_query` signature to accept `repo: str = ""`:
+
+```python
+    async def _run_query(self, prompt: str, options, issue_id: int, phase: str,
+                          allow_resume: bool = False, repo: str = "") -> AgentResult:
+```
+
+Add the telemetry call after the `logger.info("Completed...")` line:
+
+```python
+            record_query_metrics(
+                repo=repo, phase=phase, model_usage=model_usage,
+                duration_ms=duration_ms, duration_api_ms=duration_api_ms,
+            )
+```
+
+In the `except` block, before `raise AgentError(...)`:
+
+```python
+            record_query_error(repo=repo, phase=phase, model=getattr(options, "model", "unknown"))
+```
+
+Update all callers of `_run_query` to pass `repo`. Each caller has access to `issue_number` and related identifiers but not `owner/name` directly. The simplest approach: add a helper that builds the repo string, and thread it through the public methods.
+
+Add to `AgentService.__init__`:
+
+```python
+    def _repo_label(self) -> str:
+        """Build repo label from first configured repo (single-repo service)."""
+        if self.config.repos:
+            r = self.config.repos[0]
+            return f"{r.owner}/{r.name}"
+        return ""
+```
+
+Then in each `_run_query` call, pass `repo=self._repo_label()`. For example in `run_designing` (line 68):
+
+```python
+        return await self._run_query(user_prompt, options, issue_id, phase="designing", allow_resume=True, repo=self._repo_label())
+```
+
+Same pattern for `run_planning` (line 91), `run_implementation` (line 116), and `answer_question` (line 155).
+
+**Step 4: Update the test to match the actual repo value**
+
+Update the test's assertion to use `repo=""` or mock `config.repos`.
+
+**Step 5: Run test to verify it passes**
+
+Run: `pytest tests/test_agent_telemetry.py -v`
+Expected: PASS
+
+**Step 6: Run full test suite**
+
+Run: `pytest -v`
+Expected: All pass. Fix any test that calls `_run_query` and now fails due to the new import or signature.
+
+**Step 7: Commit**
+
+```bash
+git add src/remote_agent/agent.py tests/test_agent_telemetry.py
+git commit -m "feat: instrument _run_query with Prometheus telemetry recording"
+```
+
+---
+
+### Task 6: Instrument github.py.create_pr with telemetry
+
+**Files:**
+- Modify: `src/remote_agent/github.py:100-113` (`create_pr` method)
+
+**Step 1: Add telemetry call to create_pr**
+
+In `src/remote_agent/github.py`, add at the top:
+
+```python
+from remote_agent.telemetry import record_pr_created
+```
+
+In `create_pr`, after the `return` value is computed (line 113), restructure to call telemetry before returning. Replace the `create_pr` method:
+
+```python
+    async def create_pr(self, owner: str, repo: str, title: str,
+                         body: str, branch: str, draft: bool = False) -> int:
+        args = [
+            "pr", "create",
+            "--repo", f"{owner}/{repo}",
+            "--title", title,
+            "--body", body,
+            "--head", branch,
+        ]
+        if draft:
+            args.append("--draft")
+        output = await self._run_gh(args)
+        pr_url = output.strip()
+        pr_number = int(pr_url.rstrip("/").split("/")[-1])
+        record_pr_created(repo=f"{owner}/{repo}")
+        return pr_number
+```
+
+**Step 2: Run existing GitHub tests**
+
+Run: `pytest tests/ -k "github" -v`
+Expected: All pass. The `record_pr_created` is a no-op when telemetry is not initialized, so no mocking needed.
+
+**Step 3: Commit**
+
+```bash
+git add src/remote_agent/github.py
+git commit -m "feat: record PR creation metric in github.py"
+```
+
+---
+
+### Task 7: Instrument dispatcher.py phase transitions
+
+**Files:**
+- Modify: `src/remote_agent/dispatcher.py:110-112` (success path in `_process_event`)
+
+**Step 1: Add telemetry call**
+
+In `src/remote_agent/dispatcher.py`, add at the top:
+
+```python
+from remote_agent.telemetry import record_phase_transition
+```
+
+In `_process_event`, after `await self.db.update_issue_phase(issue.id, result.next_phase)` (line 112), add:
+
+```python
+            record_phase_transition(
+                repo=f"{issue.repo_owner}/{issue.repo_name}",
+                from_phase=issue.phase,
+                to_phase=result.next_phase,
+            )
+```
+
+**Step 2: Run dispatcher tests**
+
+Run: `pytest tests/ -k "dispatch" -v`
+Expected: All pass. `record_phase_transition` is a no-op when not initialized.
+
+**Step 3: Commit**
+
+```bash
+git add src/remote_agent/dispatcher.py
+git commit -m "feat: record phase transition metric in dispatcher"
+```
+
+---
+
+### Task 8: Integration test — /metrics endpoint serves Prometheus format
+
+**Files:**
+- Create: `tests/test_telemetry_integration.py`
+
+**Step 1: Write the integration test**
+
+```python
+from __future__ import annotations
+import pytest
+import remote_agent.telemetry as telemetry_module
+from remote_agent.config import TelemetryConfig
+
+
+@pytest.fixture
+def telemetry_config():
+    return TelemetryConfig(enabled=True, metrics_port=0, service_name="test-agent")
+
+
+@pytest.fixture(autouse=True)
+def reset_telemetry():
+    telemetry_module._initialized = False
+    telemetry_module._server_runner = None
+    telemetry_module._server_site = None
+    yield
+    telemetry_module._initialized = False
+    telemetry_module._server_runner = None
+    telemetry_module._server_site = None
+
+
+async def test_metrics_endpoint_serves_prometheus_format(telemetry_config):
+    """The /metrics endpoint should return Prometheus text format."""
+    telemetry_module.setup_telemetry(telemetry_config)
+
+    # Record some metrics
+    telemetry_module.record_query_metrics(
+        repo="owner/repo", phase="designing",
+        model_usage={
+            "claude-sonnet-4-6": {
+                "inputTokens": 100, "outputTokens": 50,
+                "cacheReadInputTokens": 0, "cacheCreationInputTokens": 0,
+                "costUSD": 0.01,
+            },
+        },
+        duration_ms=1000, duration_api_ms=800,
+    )
+
+    # Start the server
+    await telemetry_module.start_metrics_server(telemetry_config)
+
+    try:
+        # Get the actual port (when port=0, OS assigns one)
+        import aiohttp
+        runner = telemetry_module._server_runner
+        site = telemetry_module._server_site
+        # Access the bound socket to find actual port
+        sock = site._server.sockets[0]
+        port = sock.getsockname()[1]
+
+        async with aiohttp.ClientSession() as session:
+            async with session.get(f"http://localhost:{port}/metrics") as resp:
+                assert resp.status == 200
+                body = await resp.text()
+                assert "remote_agent_session_count_total" in body
+                assert "remote_agent_token_usage_total" in body
+                assert "remote_agent_cost_usage_total" in body
+                assert 'repo="owner/repo"' in body
+                assert 'model="claude-sonnet-4-6"' in body
+    finally:
+        await telemetry_module.shutdown_telemetry()
+```
+
+**Note:** Using `metrics_port=0` lets the OS assign a free port, avoiding port conflicts in CI.
+
+**Step 2: Run the integration test**
+
+Run: `pytest tests/test_telemetry_integration.py -v`
+Expected: PASS
+
+**Step 3: Commit**
+
+```bash
+git add tests/test_telemetry_integration.py
+git commit -m "test: add integration test for /metrics Prometheus endpoint"
+```
+
+---
+
+### Task 9: Run full test suite and fix regressions
+
+**Step 1: Run all tests**
+
+Run: `pytest -v`
+Expected: All pass. If any failures, investigate and fix.
+
+**Step 2: Common regressions to watch for**
+
+- `tests/test_main.py`: may need to mock `start_metrics_server` and `shutdown_telemetry` imports
+- `tests/test_telemetry.py`: the counter `._value.get()` pattern works for `prometheus_client` Counter objects — if it doesn't, use `REGISTRY.get_sample_value()` instead
+- Any test importing `TelemetryConfig` with `otlp_endpoint=` kwarg needs updating
+
+**Step 3: Commit any fixes**
+
+```bash
+git add -u
+git commit -m "fix: resolve test regressions from telemetry refactor"
+```
+
+---
+
+### Task 10: Clean up old design doc reference
+
+**Step 1: Mark old design as superseded**
+
+Add a note at the top of `docs/plans/2026-04-03-otel-metrics-design.md`:
+
+```markdown
+> **SUPERSEDED** by [2026-04-04-prometheus-metrics-design.md](2026-04-04-prometheus-metrics-design.md)
+```
+
+**Step 2: Commit**
+
+```bash
+git add docs/plans/2026-04-03-otel-metrics-design.md
+git commit -m "docs: mark old OTel design as superseded"
+```

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -18,10 +18,8 @@ dev = [
     "pytest-asyncio>=0.23",
 ]
 telemetry = [
-    "opentelemetry-api>=1.20.0",
-    "opentelemetry-sdk>=1.20.0",
-    "opentelemetry-exporter-otlp-proto-grpc>=1.20.0",
-    "opentelemetry-instrumentation-anthropic>=0.50.0",
+    "prometheus_client>=0.20.0",
+    "aiohttp>=3.9.0",
 ]
 
 [tool.pytest.ini_options]

--- a/src/remote_agent/agent.py
+++ b/src/remote_agent/agent.py
@@ -17,6 +17,7 @@ from remote_agent.prompts.subagents import (
     plan_reviewer_prompt, implementer_prompt, spec_reviewer_prompt,
     code_quality_reviewer_prompt, final_reviewer_prompt,
 )
+from remote_agent.telemetry import record_query_metrics, record_query_error
 
 logger = logging.getLogger(__name__)
 
@@ -43,6 +44,13 @@ class AgentService:
         self.config = config
         self.db = db
 
+    def _repo_label(self) -> str:
+        """Build repo label from first configured repo."""
+        if self.config.repos:
+            r = self.config.repos[0]
+            return f"{r.owner}/{r.name}"
+        return ""
+
     async def run_designing(self, *, issue_number: int, issue_title: str,
                              issue_body: str, cwd: str, issue_id: int,
                              existing_design: str | None = None,
@@ -65,7 +73,7 @@ class AgentService:
             cwd=cwd,
             agents=self._get_designing_subagents(issue_body),
         )
-        return await self._run_query(user_prompt, options, issue_id, phase="designing", allow_resume=True)
+        return await self._run_query(user_prompt, options, issue_id, phase="designing", allow_resume=True, repo=self._repo_label())
 
     async def run_planning(self, *, issue_number: int, issue_title: str,
                             issue_body: str, design_content: str,
@@ -88,7 +96,7 @@ class AgentService:
             cwd=cwd,
             agents=self._get_planning_subagents(),
         )
-        return await self._run_query(user_prompt, options, issue_id, phase="planning", allow_resume=True)
+        return await self._run_query(user_prompt, options, issue_id, phase="planning", allow_resume=True, repo=self._repo_label())
 
     async def run_implementation(self, *, plan_content: str, issue_title: str,
                                   issue_body: str = "", design_content: str = "",
@@ -113,7 +121,7 @@ class AgentService:
             cwd=cwd,
             agents=self._get_implementation_subagents(issue_body),
         )
-        return await self._run_query(user_prompt, options, issue_id, phase="implementing", allow_resume=True)
+        return await self._run_query(user_prompt, options, issue_id, phase="implementing", allow_resume=True, repo=self._repo_label())
 
     async def interpret_comment(self, *, comment: str, context: str,
                                  issue_title: str, issue_id: int,
@@ -152,11 +160,11 @@ class AgentService:
             max_budget_usd=1.0,
         )
 
-        result = await self._run_query(user_prompt, options, issue_id, phase=f"{context}_question")
+        result = await self._run_query(user_prompt, options, issue_id, phase=f"{context}_question", repo=self._repo_label())
         return result.result_text or ""
 
     async def _run_query(self, prompt: str, options, issue_id: int, phase: str,
-                          allow_resume: bool = False) -> AgentResult:
+                          allow_resume: bool = False, repo: str = "") -> AgentResult:
         from claude_agent_sdk import query, ResultMessage
 
         logger.info("Starting %s query for issue %d, model=%s", phase, issue_id, getattr(options, "model", "unknown"))
@@ -175,6 +183,9 @@ class AgentService:
         cost = 0.0
         input_tokens = 0
         output_tokens = 0
+        model_usage = None
+        duration_ms = 0
+        duration_api_ms = 0
 
         try:
             logger.debug("Agent prompt for issue %d phase=%s:\n%s", issue_id, phase, prompt)
@@ -187,10 +198,17 @@ class AgentService:
                     usage = message.usage or {}
                     input_tokens = usage.get("input_tokens", 0)
                     output_tokens = usage.get("output_tokens", 0)
+                    model_usage = message.model_usage
+                    duration_ms = message.duration_ms
+                    duration_api_ms = message.duration_api_ms
                     logger.debug("Agent result for issue %d phase=%s:\n%s", issue_id, phase, result_text)
 
             logger.info("Completed %s query for issue %d, cost=$%.4f, tokens=%d+%d, session=%s",
                         phase, issue_id, cost, input_tokens, output_tokens, session_id)
+            record_query_metrics(
+                repo=repo, phase=phase, model_usage=model_usage,
+                duration_ms=duration_ms, duration_api_ms=duration_api_ms,
+            )
 
             await self.db.complete_agent_run(
                 run_id, session_id=session_id, result="success",
@@ -208,6 +226,7 @@ class AgentService:
                 input_tokens=input_tokens, output_tokens=output_tokens,
                 error_message=str(e),
             )
+            record_query_error(repo=repo, phase=phase, model=getattr(options, "model", "unknown"))
             raise AgentError(str(e)) from e
 
     def _get_designing_subagents(self, issue_body: str) -> dict:

--- a/src/remote_agent/agent.py
+++ b/src/remote_agent/agent.py
@@ -226,7 +226,10 @@ class AgentService:
                 input_tokens=input_tokens, output_tokens=output_tokens,
                 error_message=str(e),
             )
-            record_query_error(repo=repo, phase=phase, model=getattr(options, "model", "unknown"))
+            # Use model_usage keys (full model names) when available, fall back to options.model
+            error_models = list(model_usage.keys()) if model_usage else [getattr(options, "model", "unknown")]
+            for m in error_models:
+                record_query_error(repo=repo, phase=phase, model=m)
             raise AgentError(str(e)) from e
 
     def _get_designing_subagents(self, issue_body: str) -> dict:

--- a/src/remote_agent/config.py
+++ b/src/remote_agent/config.py
@@ -59,7 +59,7 @@ class AutoUpdateConfig:
 @dataclass
 class TelemetryConfig:
     enabled: bool = False
-    otlp_endpoint: str = "http://localhost:4317"
+    metrics_port: int = 9090
     service_name: str = "remote-agent"
 
 

--- a/src/remote_agent/dispatcher.py
+++ b/src/remote_agent/dispatcher.py
@@ -5,6 +5,7 @@ import contextvars
 import logging
 
 from remote_agent.logging_config import current_issue_id, current_event_id
+from remote_agent.telemetry import record_phase_transition
 
 from remote_agent.config import Config
 from remote_agent.db import Database
@@ -110,6 +111,11 @@ class Dispatcher:
         try:
             result = await handler.handle(issue, event)
             await self.db.update_issue_phase(issue.id, result.next_phase)
+            record_phase_transition(
+                repo=f"{issue.repo_owner}/{issue.repo_name}",
+                from_phase=issue.phase,
+                to_phase=result.next_phase,
+            )
             if result.error_message:
                 await self.db.update_issue_error(issue.id, result.error_message)
             # Reset budget notification on successful processing

--- a/src/remote_agent/github.py
+++ b/src/remote_agent/github.py
@@ -4,6 +4,8 @@ import asyncio
 import json
 import logging
 
+from remote_agent.telemetry import record_pr_created
+
 logger = logging.getLogger(__name__)
 
 from remote_agent.exceptions import GitHubError
@@ -110,7 +112,9 @@ class GitHubService:
             args.append("--draft")
         output = await self._run_gh(args)
         pr_url = output.strip()
-        return int(pr_url.rstrip("/").split("/")[-1])
+        pr_number = int(pr_url.rstrip("/").split("/")[-1])
+        record_pr_created(repo=f"{owner}/{repo}")
+        return pr_number
 
     async def mark_pr_ready(self, owner: str, repo: str, pr_number: int) -> None:
         await self._run_gh(["pr", "ready", str(pr_number), "--repo", f"{owner}/{repo}"])

--- a/src/remote_agent/main.py
+++ b/src/remote_agent/main.py
@@ -14,7 +14,7 @@ from remote_agent.poller import Poller
 from remote_agent.dispatcher import Dispatcher
 from remote_agent.audit import AuditLogger
 from remote_agent.updater import AutoUpdater
-from remote_agent.telemetry import setup_telemetry
+from remote_agent.telemetry import setup_telemetry, start_metrics_server, shutdown_telemetry
 
 logger = logging.getLogger("remote_agent")
 
@@ -56,6 +56,7 @@ async def run(config_path: str = "config.yaml"):
     setup_logging(app.config)
 
     setup_telemetry(app.config.telemetry)
+    await start_metrics_server(app.config.telemetry)
 
     logger.info("Remote agent started. Polling %d repos every %ds.",
                 len(app.config.repos), app.config.polling.interval_seconds)
@@ -84,6 +85,7 @@ async def run(config_path: str = "config.yaml"):
         if app.audit:
             app.audit.close()
         await app.db.close()
+        await shutdown_telemetry()
 
 
 def main():

--- a/src/remote_agent/telemetry.py
+++ b/src/remote_agent/telemetry.py
@@ -184,4 +184,5 @@ async def shutdown_telemetry() -> None:
         await _server_runner.cleanup()
         _server_runner = None
         _server_site = None
+        _initialized = False
         logger.info("Metrics server stopped")

--- a/src/remote_agent/telemetry.py
+++ b/src/remote_agent/telemetry.py
@@ -8,19 +8,126 @@ from remote_agent.config import TelemetryConfig
 logger = logging.getLogger(__name__)
 
 try:
-    from opentelemetry import trace
-    from opentelemetry.sdk.trace import TracerProvider
-    from opentelemetry.sdk.trace.export import BatchSpanProcessor
-    from opentelemetry.exporter.otlp.proto.grpc.trace_exporter import OTLPSpanExporter
-    from opentelemetry.sdk.resources import Resource
-    from opentelemetry.instrumentation.anthropic import AnthropicInstrumentor
+    from prometheus_client import Counter, CollectorRegistry, generate_latest
+    from aiohttp import web
 
-    HAS_OTEL = True
+    HAS_PROMETHEUS = True
 except ImportError:
-    HAS_OTEL = False
+    HAS_PROMETHEUS = False
 
 
 _initialized = False
+_server_runner: object | None = None
+_server_site: object | None = None
+
+# -- Metric definitions (safe to define even if prometheus_client missing) --
+
+if HAS_PROMETHEUS:
+    REGISTRY = CollectorRegistry()
+
+    SESSION_COUNT = Counter(
+        "remote_agent_session_count_total",
+        "Count of agent query sessions",
+        ["repo", "phase", "model"],
+        registry=REGISTRY,
+    )
+
+    TOKEN_USAGE = Counter(
+        "remote_agent_token_usage_total",
+        "Number of tokens used",
+        ["repo", "phase", "model", "type"],
+        registry=REGISTRY,
+    )
+
+    COST_USAGE = Counter(
+        "remote_agent_cost_usage_total",
+        "Cost of agent queries in USD",
+        ["repo", "phase", "model"],
+        registry=REGISTRY,
+    )
+
+    ACTIVE_TIME = Counter(
+        "remote_agent_active_time_total",
+        "Total active time in seconds",
+        ["repo", "phase", "type"],
+        registry=REGISTRY,
+    )
+
+    QUERY_ERRORS = Counter(
+        "remote_agent_query_errors_total",
+        "Count of failed agent queries",
+        ["repo", "phase", "model"],
+        registry=REGISTRY,
+    )
+
+    PR_COUNT = Counter(
+        "remote_agent_pull_request_count_total",
+        "Number of pull requests created",
+        ["repo"],
+        registry=REGISTRY,
+    )
+
+    PHASE_TRANSITIONS = Counter(
+        "remote_agent_phase_transitions_total",
+        "Count of issue phase transitions",
+        ["repo", "from_phase", "to_phase"],
+        registry=REGISTRY,
+    )
+
+
+# -- Record functions (no-op when not initialized) --
+
+
+def record_query_metrics(
+    *, repo: str, phase: str, model_usage: dict | None,
+    duration_ms: int, duration_api_ms: int,
+) -> None:
+    if not _initialized or not model_usage:
+        return
+
+    for model, usage in model_usage.items():
+        SESSION_COUNT.labels(repo=repo, phase=phase, model=model).inc()
+        COST_USAGE.labels(repo=repo, phase=phase, model=model).inc(
+            usage.get("costUSD", 0),
+        )
+        for token_type, key in [
+            ("input", "inputTokens"),
+            ("output", "outputTokens"),
+            ("cacheRead", "cacheReadInputTokens"),
+            ("cacheCreation", "cacheCreationInputTokens"),
+        ]:
+            TOKEN_USAGE.labels(
+                repo=repo, phase=phase, model=model, type=token_type,
+            ).inc(usage.get(key, 0))
+
+    ACTIVE_TIME.labels(repo=repo, phase=phase, type="agent").inc(duration_ms / 1000)
+    ACTIVE_TIME.labels(repo=repo, phase=phase, type="api").inc(duration_api_ms / 1000)
+
+
+def record_query_error(*, repo: str, phase: str, model: str) -> None:
+    if not _initialized:
+        return
+    QUERY_ERRORS.labels(repo=repo, phase=phase, model=model).inc()
+
+
+def record_pr_created(*, repo: str) -> None:
+    if not _initialized:
+        return
+    PR_COUNT.labels(repo=repo).inc()
+
+
+def record_phase_transition(*, repo: str, from_phase: str, to_phase: str) -> None:
+    if not _initialized:
+        return
+    PHASE_TRANSITIONS.labels(repo=repo, from_phase=from_phase, to_phase=to_phase).inc()
+
+
+# -- Server lifecycle --
+
+
+async def _metrics_handler(request: web.Request) -> web.Response:
+    body = generate_latest(REGISTRY)
+    return web.Response(body=body, content_type="text/plain; version=0.0.4; charset=utf-8")
 
 
 def setup_telemetry(config: TelemetryConfig) -> None:
@@ -32,24 +139,45 @@ def setup_telemetry(config: TelemetryConfig) -> None:
     if _initialized:
         return
 
-    if not HAS_OTEL:
+    if not HAS_PROMETHEUS:
         logger.warning(
-            "Telemetry enabled but opentelemetry packages not installed. "
+            "Telemetry enabled but prometheus_client/aiohttp not installed. "
             "Install with: pip install -e '.[telemetry]'"
         )
         return
 
-    resource = Resource.create({"service.name": config.service_name})
-    provider = TracerProvider(resource=resource)
-    exporter = OTLPSpanExporter(endpoint=config.otlp_endpoint)
-    provider.add_span_processor(BatchSpanProcessor(exporter))
-    trace.set_tracer_provider(provider)
-
-    AnthropicInstrumentor().instrument()
     _initialized = True
-
     logger.info(
-        "Telemetry enabled: exporting to %s as %s",
-        config.otlp_endpoint,
-        config.service_name,
+        "Telemetry enabled: /metrics on port %d as %s",
+        config.metrics_port, config.service_name,
     )
+
+
+async def start_metrics_server(config: TelemetryConfig) -> None:
+    global _server_runner, _server_site
+
+    if not _initialized:
+        return
+
+    app = web.Application()
+    app.router.add_get("/metrics", _metrics_handler)
+
+    runner = web.AppRunner(app)
+    await runner.setup()
+    site = web.TCPSite(runner, "0.0.0.0", config.metrics_port)
+    await site.start()
+
+    _server_runner = runner
+    _server_site = site
+
+    logger.info("Metrics server listening on port %d", config.metrics_port)
+
+
+async def shutdown_telemetry() -> None:
+    global _server_runner, _server_site, _initialized
+
+    if _server_runner:
+        await _server_runner.cleanup()
+        _server_runner = None
+        _server_site = None
+        logger.info("Metrics server stopped")

--- a/src/remote_agent/telemetry.py
+++ b/src/remote_agent/telemetry.py
@@ -127,7 +127,11 @@ def record_phase_transition(*, repo: str, from_phase: str, to_phase: str) -> Non
 
 async def _metrics_handler(request: web.Request) -> web.Response:
     body = generate_latest(REGISTRY)
-    return web.Response(body=body, content_type="text/plain; version=0.0.4; charset=utf-8")
+    return web.Response(
+        body=body,
+        content_type="text/plain; version=0.0.4",
+        charset="utf-8",
+    )
 
 
 def setup_telemetry(config: TelemetryConfig) -> None:

--- a/tests/test_agent_telemetry.py
+++ b/tests/test_agent_telemetry.py
@@ -1,0 +1,115 @@
+from __future__ import annotations
+from unittest.mock import patch, AsyncMock, MagicMock
+from dataclasses import dataclass, field
+from remote_agent.agent import AgentService
+
+
+@dataclass
+class FakeResultMessage:
+    subtype: str = "result"
+    duration_ms: int = 5000
+    duration_api_ms: int = 4000
+    is_error: bool = False
+    num_turns: int = 3
+    session_id: str = "test-session"
+    total_cost_usd: float = 0.05
+    usage: dict = field(default_factory=lambda: {"input_tokens": 1500, "output_tokens": 800})
+    result: str = "done"
+    model_usage: dict = field(default_factory=lambda: {
+        "claude-sonnet-4-6": {
+            "inputTokens": 1500,
+            "outputTokens": 800,
+            "cacheReadInputTokens": 0,
+            "cacheCreationInputTokens": 0,
+            "costUSD": 0.05,
+        }
+    })
+
+
+async def test_run_query_calls_record_query_metrics():
+    """_run_query should call record_query_metrics with model_usage from ResultMessage."""
+    mock_db = MagicMock()
+    mock_db.create_agent_run = AsyncMock(return_value=1)
+    mock_db.get_latest_session_for_phase = AsyncMock(return_value=None)
+    mock_db.complete_agent_run = AsyncMock()
+
+    mock_config = MagicMock()
+    mock_config.repos = []
+    service = AgentService(mock_config, mock_db)
+
+    msg = FakeResultMessage()
+
+    async def fake_query(**kwargs):
+        yield msg
+
+    mock_options = MagicMock()
+    mock_options.model = "sonnet"
+
+    with (
+        patch("claude_agent_sdk.query", side_effect=fake_query),
+        patch("claude_agent_sdk.ResultMessage", FakeResultMessage),
+        patch("remote_agent.agent.record_query_metrics") as mock_record,
+    ):
+        await service._run_query("test prompt", mock_options, issue_id=1, phase="designing")
+
+        mock_record.assert_called_once_with(
+            repo="",
+            phase="designing",
+            model_usage=msg.model_usage,
+            duration_ms=5000,
+            duration_api_ms=4000,
+        )
+
+
+async def test_run_query_calls_record_query_error_on_failure():
+    """_run_query should call record_query_error when query raises."""
+    mock_db = MagicMock()
+    mock_db.create_agent_run = AsyncMock(return_value=1)
+    mock_db.get_latest_session_for_phase = AsyncMock(return_value=None)
+    mock_db.complete_agent_run = AsyncMock()
+
+    mock_config = MagicMock()
+    mock_config.repos = []
+    service = AgentService(mock_config, mock_db)
+
+    async def failing_query(**kwargs):
+        raise RuntimeError("API error")
+        yield  # make it an async generator
+
+    mock_options = MagicMock()
+    mock_options.model = "sonnet"
+
+    with (
+        patch("claude_agent_sdk.query", side_effect=failing_query),
+        patch("claude_agent_sdk.ResultMessage"),
+        patch("remote_agent.agent.record_query_error") as mock_error,
+    ):
+        import pytest
+        from remote_agent.exceptions import AgentError
+        with pytest.raises(AgentError):
+            await service._run_query("test prompt", mock_options, issue_id=1, phase="designing")
+
+        mock_error.assert_called_once_with(
+            repo="", phase="designing", model="sonnet",
+        )
+
+
+async def test_repo_label_from_config():
+    """_repo_label should build owner/name from first configured repo."""
+    mock_config = MagicMock()
+    repo = MagicMock()
+    repo.owner = "myorg"
+    repo.name = "myrepo"
+    mock_config.repos = [repo]
+
+    service = AgentService(mock_config, MagicMock())
+    assert service._repo_label() == "myorg/myrepo"
+
+
+async def test_repo_label_empty_when_no_repos():
+    """_repo_label should return empty string when no repos configured."""
+    mock_config = MagicMock()
+    mock_config.repos = []
+
+    service = AgentService(mock_config, MagicMock())
+    assert service._repo_label() == ""

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -169,7 +169,7 @@ agent:
 """)
     config = load_config(str(config_file))
     assert config.telemetry.enabled is False
-    assert config.telemetry.otlp_endpoint == "http://localhost:4317"
+    assert config.telemetry.metrics_port == 9090
     assert config.telemetry.service_name == "remote-agent"
 
 
@@ -200,13 +200,24 @@ agent:
   daily_budget_usd: 50.0
 telemetry:
   enabled: true
-  otlp_endpoint: "http://collector:4317"
+  metrics_port: 9191
   service_name: "my-agent"
 """)
     config = load_config(str(config_file))
     assert config.telemetry.enabled is True
-    assert config.telemetry.otlp_endpoint == "http://collector:4317"
+    assert config.telemetry.metrics_port == 9191
     assert config.telemetry.service_name == "my-agent"
+
+
+def test_telemetry_config_metrics_port():
+    """TelemetryConfig should have metrics_port, not otlp_endpoint."""
+    from remote_agent.config import TelemetryConfig
+
+    config = TelemetryConfig()
+    assert config.metrics_port == 9090
+    assert config.service_name == "remote-agent"
+    assert config.enabled is False
+    assert not hasattr(config, "otlp_endpoint")
 
 
 def test_agent_config_default_orchestrator_model_is_sonnet():

--- a/tests/test_main.py
+++ b/tests/test_main.py
@@ -281,12 +281,14 @@ agent:
   daily_budget_usd: 50.0
 telemetry:
   enabled: true
-  otlp_endpoint: "http://collector:4317"
+  metrics_port: 9999
   service_name: "test-agent"
 """)
     with patch("remote_agent.main.Poller") as mock_poller_cls, \
          patch("remote_agent.main.Dispatcher") as mock_disp_cls, \
-         patch("remote_agent.main.setup_telemetry") as mock_setup_tel:
+         patch("remote_agent.main.setup_telemetry") as mock_setup_tel, \
+         patch("remote_agent.main.start_metrics_server", new_callable=AsyncMock) as mock_start, \
+         patch("remote_agent.main.shutdown_telemetry", new_callable=AsyncMock) as mock_shutdown:
         mock_poller_cls.return_value = AsyncMock()
         mock_disp = AsyncMock()
         mock_disp.process_events.side_effect = KeyboardInterrupt
@@ -299,4 +301,6 @@ telemetry:
         mock_setup_tel.assert_called_once()
         call_arg = mock_setup_tel.call_args[0][0]
         assert call_arg.enabled is True
-        assert call_arg.otlp_endpoint == "http://collector:4317"
+        assert call_arg.metrics_port == 9999
+        mock_start.assert_called_once()
+        mock_shutdown.assert_called_once()

--- a/tests/test_telemetry.py
+++ b/tests/test_telemetry.py
@@ -1,59 +1,171 @@
 from __future__ import annotations
-from unittest.mock import patch, MagicMock
+from unittest.mock import patch, AsyncMock, MagicMock
 import pytest
 from remote_agent.config import TelemetryConfig
-from remote_agent.telemetry import setup_telemetry
 import remote_agent.telemetry as telemetry_module
 
 
 @pytest.fixture(autouse=True)
 def reset_telemetry_state():
     telemetry_module._initialized = False
+    telemetry_module._server_runner = None
+    telemetry_module._server_site = None
     yield
     telemetry_module._initialized = False
+    telemetry_module._server_runner = None
+    telemetry_module._server_site = None
+
+
+def test_record_query_metrics_disabled_is_noop():
+    """record_query_metrics should silently do nothing when telemetry is not initialized."""
+    telemetry_module.record_query_metrics(
+        repo="owner/repo", phase="designing",
+        model_usage={"claude-sonnet-4-6": {"inputTokens": 100, "outputTokens": 50, "costUSD": 0.01}},
+        duration_ms=1000, duration_api_ms=800,
+    )
+
+
+def test_record_query_metrics_increments_counters():
+    """record_query_metrics should increment all metric counters when enabled."""
+    with patch("remote_agent.telemetry.HAS_PROMETHEUS", True):
+        telemetry_module._initialized = True
+
+        model_usage = {
+            "claude-sonnet-4-6": {
+                "inputTokens": 1500,
+                "outputTokens": 800,
+                "cacheReadInputTokens": 100,
+                "cacheCreationInputTokens": 200,
+                "costUSD": 0.015,
+            },
+        }
+
+        telemetry_module.record_query_metrics(
+            repo="owner/repo", phase="designing",
+            model_usage=model_usage,
+            duration_ms=5000, duration_api_ms=4000,
+        )
+
+        val = telemetry_module.SESSION_COUNT.labels(
+            repo="owner/repo", phase="designing", model="claude-sonnet-4-6",
+        )._value.get()
+        assert val == 1.0
+
+        val = telemetry_module.TOKEN_USAGE.labels(
+            repo="owner/repo", phase="designing", model="claude-sonnet-4-6", type="input",
+        )._value.get()
+        assert val == 1500.0
+
+        val = telemetry_module.TOKEN_USAGE.labels(
+            repo="owner/repo", phase="designing", model="claude-sonnet-4-6", type="cacheRead",
+        )._value.get()
+        assert val == 100.0
+
+        val = telemetry_module.COST_USAGE.labels(
+            repo="owner/repo", phase="designing", model="claude-sonnet-4-6",
+        )._value.get()
+        assert val == 0.015
+
+        val = telemetry_module.ACTIVE_TIME.labels(
+            repo="owner/repo", phase="designing", type="agent",
+        )._value.get()
+        assert val == 5.0
+
+        val = telemetry_module.ACTIVE_TIME.labels(
+            repo="owner/repo", phase="designing", type="api",
+        )._value.get()
+        assert val == 4.0
+
+
+def test_record_query_metrics_multiple_models():
+    """record_query_metrics should handle multi-model usage (subagents)."""
+    with patch("remote_agent.telemetry.HAS_PROMETHEUS", True):
+        telemetry_module._initialized = True
+
+        model_usage = {
+            "claude-sonnet-4-6": {
+                "inputTokens": 1000, "outputTokens": 500,
+                "cacheReadInputTokens": 0, "cacheCreationInputTokens": 0,
+                "costUSD": 0.01,
+            },
+            "claude-opus-4-6[1m]": {
+                "inputTokens": 2000, "outputTokens": 1000,
+                "cacheReadInputTokens": 500, "cacheCreationInputTokens": 100,
+                "costUSD": 0.05,
+            },
+        }
+
+        telemetry_module.record_query_metrics(
+            repo="owner/repo", phase="implementing",
+            model_usage=model_usage,
+            duration_ms=10000, duration_api_ms=8000,
+        )
+
+        val_sonnet = telemetry_module.SESSION_COUNT.labels(
+            repo="owner/repo", phase="implementing", model="claude-sonnet-4-6",
+        )._value.get()
+        val_opus = telemetry_module.SESSION_COUNT.labels(
+            repo="owner/repo", phase="implementing", model="claude-opus-4-6[1m]",
+        )._value.get()
+        assert val_sonnet == 1.0
+        assert val_opus == 1.0
+
+
+def test_record_query_error_increments_counter():
+    """record_query_error should increment the error counter."""
+    with patch("remote_agent.telemetry.HAS_PROMETHEUS", True):
+        telemetry_module._initialized = True
+
+        telemetry_module.record_query_error(
+            repo="owner/repo", phase="designing", model="claude-sonnet-4-6",
+        )
+
+        val = telemetry_module.QUERY_ERRORS.labels(
+            repo="owner/repo", phase="designing", model="claude-sonnet-4-6",
+        )._value.get()
+        assert val == 1.0
+
+
+def test_record_pr_created_increments_counter():
+    """record_pr_created should increment the PR counter."""
+    with patch("remote_agent.telemetry.HAS_PROMETHEUS", True):
+        telemetry_module._initialized = True
+
+        telemetry_module.record_pr_created(repo="owner/repo")
+
+        val = telemetry_module.PR_COUNT.labels(repo="owner/repo")._value.get()
+        assert val == 1.0
+
+
+def test_record_phase_transition_increments_counter():
+    """record_phase_transition should increment the transition counter."""
+    with patch("remote_agent.telemetry.HAS_PROMETHEUS", True):
+        telemetry_module._initialized = True
+
+        telemetry_module.record_phase_transition(
+            repo="owner/repo", from_phase="designing", to_phase="design_review",
+        )
+
+        val = telemetry_module.PHASE_TRANSITIONS.labels(
+            repo="owner/repo", from_phase="designing", to_phase="design_review",
+        )._value.get()
+        assert val == 1.0
 
 
 def test_setup_telemetry_disabled_is_noop():
+    """setup_telemetry should be a no-op when disabled."""
     config = TelemetryConfig(enabled=False)
-    with patch("remote_agent.telemetry.HAS_OTEL", True), \
-         patch("remote_agent.telemetry.TracerProvider") as mock_tp:
-        setup_telemetry(config)
-        mock_tp.assert_not_called()
-
-
-def test_setup_telemetry_enabled_configures_provider():
-    config = TelemetryConfig(
-        enabled=True,
-        otlp_endpoint="http://localhost:4317",
-        service_name="test-agent",
-    )
-    mock_instrumentor = MagicMock()
-    with (
-        patch("remote_agent.telemetry.TracerProvider") as mock_tp_cls,
-        patch("remote_agent.telemetry.OTLPSpanExporter") as mock_exporter_cls,
-        patch("remote_agent.telemetry.BatchSpanProcessor") as mock_bsp_cls,
-        patch("remote_agent.telemetry.trace") as mock_trace,
-        patch("remote_agent.telemetry.AnthropicInstrumentor", return_value=mock_instrumentor) as mock_instr_cls,
-        patch("remote_agent.telemetry.Resource") as mock_resource_cls,
-    ):
-        setup_telemetry(config)
-
-        # Verify provider was created and set
-        mock_tp_cls.assert_called_once()
-        mock_trace.set_tracer_provider.assert_called_once()
-
-        # Verify exporter uses configured endpoint
-        mock_exporter_cls.assert_called_once_with(endpoint="http://localhost:4317")
-
-        # Verify instrumentor was called
-        mock_instrumentor.instrument.assert_called_once()
+    telemetry_module.setup_telemetry(config)
+    assert not telemetry_module._initialized
 
 
 def test_setup_telemetry_missing_deps_logs_warning():
+    """setup_telemetry should warn when prometheus_client is not installed."""
     config = TelemetryConfig(enabled=True)
     with (
-        patch("remote_agent.telemetry.HAS_OTEL", False),
+        patch("remote_agent.telemetry.HAS_PROMETHEUS", False),
         patch("remote_agent.telemetry.logger") as mock_logger,
     ):
-        setup_telemetry(config)
+        telemetry_module.setup_telemetry(config)
         mock_logger.warning.assert_called_once()
+        assert not telemetry_module._initialized

--- a/tests/test_telemetry_integration.py
+++ b/tests/test_telemetry_integration.py
@@ -1,0 +1,79 @@
+from __future__ import annotations
+import pytest
+import aiohttp
+import remote_agent.telemetry as telemetry_module
+from remote_agent.config import TelemetryConfig
+
+
+@pytest.fixture(autouse=True)
+def reset_telemetry():
+    telemetry_module._initialized = False
+    telemetry_module._server_runner = None
+    telemetry_module._server_site = None
+    yield
+    telemetry_module._initialized = False
+    telemetry_module._server_runner = None
+    telemetry_module._server_site = None
+
+
+async def test_metrics_endpoint_serves_prometheus_format():
+    """The /metrics endpoint should return Prometheus text format with recorded metrics."""
+    config = TelemetryConfig(enabled=True, metrics_port=0, service_name="test-agent")
+    telemetry_module.setup_telemetry(config)
+
+    # Record some metrics before starting server
+    telemetry_module.record_query_metrics(
+        repo="owner/repo", phase="designing",
+        model_usage={
+            "claude-sonnet-4-6": {
+                "inputTokens": 100, "outputTokens": 50,
+                "cacheReadInputTokens": 0, "cacheCreationInputTokens": 0,
+                "costUSD": 0.01,
+            },
+        },
+        duration_ms=1000, duration_api_ms=800,
+    )
+
+    await telemetry_module.start_metrics_server(config)
+
+    try:
+        # Get the actual port assigned by OS (port=0 means ephemeral)
+        site = telemetry_module._server_site
+        sock = site._server.sockets[0]
+        port = sock.getsockname()[1]
+
+        async with aiohttp.ClientSession() as session:
+            async with session.get(f"http://localhost:{port}/metrics") as resp:
+                assert resp.status == 200
+                body = await resp.text()
+
+                # Verify metric names present
+                assert "remote_agent_session_count_total" in body
+                assert "remote_agent_token_usage_total" in body
+                assert "remote_agent_cost_usage_total" in body
+                assert "remote_agent_active_time_total" in body
+
+                # Verify labels present
+                assert 'repo="owner/repo"' in body
+                assert 'model="claude-sonnet-4-6"' in body
+                assert 'phase="designing"' in body
+    finally:
+        await telemetry_module.shutdown_telemetry()
+
+
+async def test_metrics_endpoint_404_on_other_paths():
+    """Non-/metrics paths should return 404."""
+    config = TelemetryConfig(enabled=True, metrics_port=0, service_name="test-agent")
+    telemetry_module.setup_telemetry(config)
+    await telemetry_module.start_metrics_server(config)
+
+    try:
+        site = telemetry_module._server_site
+        sock = site._server.sockets[0]
+        port = sock.getsockname()[1]
+
+        async with aiohttp.ClientSession() as session:
+            async with session.get(f"http://localhost:{port}/") as resp:
+                assert resp.status == 404
+    finally:
+        await telemetry_module.shutdown_telemetry()


### PR DESCRIPTION
## Summary

Replaces the OTLP gRPC push-based telemetry (PR #13) with an in-process `/metrics` HTTP endpoint that Prometheus can scrape directly. The service runs on an isolated VM with no access to an external OTel Collector, making push-based export unworkable.

- **Swaps dependencies**: removes 4 `opentelemetry-*` packages, adds `prometheus_client` + `aiohttp`
- **Rewrites `telemetry.py`**: 7 Prometheus counters aligned with Claude Code's `claude_code_*` naming conventions (`session_count`, `token_usage`, `cost_usage`, `active_time`, `query_errors`, `pull_request_count`, `phase_transitions`)
- **Instruments `agent.py`**: extracts `model_usage` (per-model token/cost breakdown with cache types) and `duration_ms`/`duration_api_ms` from SDK's `ResultMessage`
- **Instruments `github.py` and `dispatcher.py`**: PR creation and phase transition metrics
- **Adds aiohttp server lifecycle** to `main.py` (`start_metrics_server` / `shutdown_telemetry`)
- **Config change**: `TelemetryConfig.otlp_endpoint` → `metrics_port: int = 9090`

## Test plan
- [x] 262 tests passing (0 failures)
- [x] Unit tests for all `record_*` functions (enabled/disabled, multi-model)
- [x] Integration test: starts server on ephemeral port, records metrics, GETs `/metrics`, verifies Prometheus text format output with correct metric names and labels
- [x] Existing agent/github/dispatcher/main tests unaffected